### PR TITLE
Fix: Persist ServiceDefinition type information

### DIFF
--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -16,8 +16,8 @@ export type ServiceDefinition = {
   };
 };
 
-export type RegisteredService = {
-  definition: ServiceDefinition;
+export type RegisteredService<T extends ServiceDefinition> = {
+  definition: T;
   start: () => Promise<void>;
   stop: () => Promise<void>;
 };
@@ -488,7 +488,7 @@ export class Differential {
    * });
    * ```
    */
-  service<T extends ServiceDefinition>(service: T): RegisteredService {
+  service<T extends ServiceDefinition>(service: T): RegisteredService<T> {
     for (const [key, value] of Object.entries(service.functions)) {
       if (functionRegistry[key]) {
         throw new DifferentialError(
@@ -527,7 +527,7 @@ export class Differential {
    * ```
    */
   async call<
-    T extends RegisteredService,
+    T extends RegisteredService<any>,
     U extends keyof T["definition"]["functions"]
   >(
     fn: U,
@@ -570,7 +570,7 @@ export class Differential {
    * ```
    */
   async background<
-    T extends RegisteredService,
+    T extends RegisteredService<any>,
     U extends keyof T["definition"]["functions"]
   >(
     fn: U,
@@ -583,7 +583,7 @@ export class Differential {
   }
 
   private async createJob<
-    T extends RegisteredService,
+    T extends RegisteredService<any>,
     U extends keyof T["definition"]["functions"]
   >(
     fn: string | number | symbol,


### PR DESCRIPTION
`d.service` is omitting type information which result in no type checking for subsequent `d.call` and `d.background` functions.

Update `RegisteredService` type to be generic, allowing for more specific `ServiceDefinition`  information to be retained.

## Before
<img width="1138" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/f02a9938-1fad-4bc5-ac0d-8295af5d3659">

## After
<img width="1287" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/9ddc09e3-6b25-4bd5-8757-856730e2a42d">
