### PR TITLE
Add service client builder

### DIFF
--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -522,7 +522,7 @@ export class Differential {
    * @example
    * ```ts
    * import { d } from "./differential";
-   * import { helloService } from "./hello-service";
+   * import type { helloService } from "./hello-service";
    *
    * const client = d.buildClient<typeof helloService>();
    *

--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -515,13 +515,10 @@ export class Differential {
     };
   }
 
-  buildClient<T extends RegisteredService<any>>(service: T): ServiceClient<T> {
+  buildClient<T extends RegisteredService<any>>(): ServiceClient<T> {
     const d = this
-    return new Proxy(service.definition.functions, {
+    return new Proxy({} as ServiceClient<T>, {
       get(_target, property, _receiver) {
-        if (service.definition.functions[property] === undefined || typeof property === 'symbol') {
-          return undefined;
-        }
         return (...args: any[]) => { return d.call(property, ...args) }
       }
     });

--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -515,6 +515,22 @@ export class Differential {
     };
   }
 
+  /**
+   * Provides a type safe client for performing calls to a registered service.
+   * Waits for the function to complete before returning, and returns the result of the function call.
+   * @returns ServiceClient<T>
+   * @example
+   * ```ts
+   * import { d } from "./differential";
+   * import { helloService } from "./hello-service";
+   *
+   * const client = d.buildClient<typeof helloService>();
+   *
+   * // Client usage
+   * const result = client.hello("world");
+   * console.log(result); // "Hello world"
+   * ```
+   */
   buildClient<T extends RegisteredService<any>>(): ServiceClient<T> {
     const d = this
     return new Proxy({} as ServiceClient<T>, {

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -30,6 +30,22 @@ describe("monolith", () => {
     await expertService.stop();
   }, 10000);
 
+  it("service client should return the same result", async () => {
+    await expertService.start();
+
+    const result = await d.call<typeof expertService, "callExpert">(
+      "callExpert",
+      "Can't touch this"
+    );
+    
+    const client = d.buildClient(expertService)
+    const clientResult = await client.callExpert("Can't touch this")
+
+    expect(clientResult).toBe(result);
+
+    await expertService.stop();
+  }, 10000);
+
   it("should be able to call a service from another service", async () => {
     await facadeService.start();
     await expertService.start();

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -39,7 +39,7 @@ describe("monolith", () => {
     );
 
     const client = d.buildClient<typeof expertService>()
-    client.callExpert("Can't touch this")
+    const clientResult = await client.callExpert("Can't touch this")
 
     expect(clientResult).toBe(result);
 

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -37,9 +37,9 @@ describe("monolith", () => {
       "callExpert",
       "Can't touch this"
     );
-    
-    const client = d.buildClient(expertService)
-    const clientResult = await client.callExpert("Can't touch this")
+
+    const client = d.buildClient<typeof expertService>()
+    client.callExpert("Can't touch this")
 
     expect(clientResult).toBe(result);
 

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -30,7 +30,7 @@ describe("monolith", () => {
     await expertService.stop();
   }, 10000);
 
-  it("service client should return the same result", async () => {
+  it("service client should return the same result as 'call'", async () => {
     await expertService.start();
 
     const result = await d.call<typeof expertService, "callExpert">(


### PR DESCRIPTION
Adds a `buildClient()` function which produces a type-safe service client for easier ergonomics.

Usage:
```
const client = d.buildClient<typeof expertService>()
await client.callExpert("Can't touch this")
```