### PR TITLE
fix: Enforce service name param

### DIFF
--- a/changeset-builder/logs/ts-core.csv
+++ b/changeset-builder/logs/ts-core.csv
@@ -1,3 +1,4 @@
+439e942, 2023-12-24, Enforce service name param
 a218b31, 2023-12-23, release: 3.1.0
 f191698, 2023-12-23, Add service client builder (#2)
 e74b43b, 2023-12-22, Fix: Persist ServiceDefinition type information (#1)

--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -14,14 +14,14 @@ type ServiceClient<T extends RegisteredService<any>> = {
   [K in keyof T['definition']['functions']]: T['definition']['functions'][K];
 };
 
-export type ServiceDefinition = {
-  name: string;
+export type ServiceDefinition<T extends string> = {
+  name: T;
   functions: {
     [key: string]: AsyncFunction;
   };
 };
 
-export type RegisteredService<T extends ServiceDefinition> = {
+export type RegisteredService<T extends ServiceDefinition<any>> = {
   definition: T;
   start: () => Promise<void>;
   stop: () => Promise<void>;
@@ -493,7 +493,7 @@ export class Differential {
    * });
    * ```
    */
-  service<T extends ServiceDefinition>(service: T): RegisteredService<T> {
+  service<T extends ServiceDefinition<N>, N extends string>(service: T): RegisteredService<T> {
     for (const [key, value] of Object.entries(service.functions)) {
       if (functionRegistry[key]) {
         throw new DifferentialError(
@@ -531,7 +531,7 @@ export class Differential {
    * console.log(result); // "Hello world"
    * ```
    */
-  buildClient<T extends RegisteredService<any>>(): ServiceClient<T> {
+  buildClient<T extends RegisteredService<any> >(service: T['definition']['name']): ServiceClient<T> {
     const d = this
     return new Proxy({} as ServiceClient<T>, {
       get(_target, property, _receiver) {

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -38,7 +38,7 @@ describe("monolith", () => {
       "Can't touch this"
     );
 
-    const client = d.buildClient<typeof expertService>()
+    const client = d.buildClient<typeof expertService>('expert')
     const clientResult = await client.callExpert("Can't touch this")
 
     expect(clientResult).toBe(result);


### PR DESCRIPTION
Add (currently unused) type-safe `service` param to `buildClient` to make service name available at runtime.

<img width="1338" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/78968a4c-eb54-49fb-9a40-ac9a75bb9f92">
