### PR TITLE
fix: use workspace dependency rather than registry

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "build": "make sync-api-docs"
   },
   "dependencies": {
-    "@differentialhq/core": "latest"
+    "@differentialhq/core": "3.1.4"
   },
   "author": "",
   "license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,18 +54,7 @@
       "version": "0.0.36",
       "license": "ISC",
       "dependencies": {
-        "@differentialhq/core": "latest"
-      }
-    },
-    "docs/node_modules/@differentialhq/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@differentialhq/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-jnq7nBV5ebR/w69W7b+OKYce06MIriBJtHRFbraiadbVgeogecVTmdV1UWc5/iIQshKmQx8EQGuk+Bhtz4GvHQ==",
-      "dependencies": {
-        "@ts-rest/core": "^3.28.0",
-        "debug": "^4.3.4",
-        "msgpackr": "^1.9.7",
-        "zod": "^3.22.2"
+        "@differentialhq/core": "3.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
`npm install` is attempting to resolve the `@differentialhq/core` package from NPM rather than the local NPM `workspace`.

For what ever reason, the `package-lock.json` is [attempting to fetch](https://github.com/differentialhq/differential/actions/runs/7327195278/job/19953769912) a version which is not yet published (3.2.0) causing the pipeline to fail.

Pin `docs` `@differentialhq/core` dependency to the current version. This should be incremented automatically by `learna version`.