### PR TITLE
fix: Shard jobs by the service name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,6 @@ jobs:
           DIFFERENTIAL_API_SECRET: ${{ secrets.DIFFERENTIAL_API_SECRET }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           JWKS_URL: ${{ secrets.JWKS_URL }}
+
+      - name: Test builds
+        run: npx lerna run build

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -21,6 +21,7 @@ export const contract = c.router({
       pools: z.string().optional(),
       limit: z.coerce.number().default(1),
       functions: z.string().optional(),
+      service: z.string().optional(),
     }),
     responses: {
       200: z.array(NextJobSchema),
@@ -43,6 +44,7 @@ export const contract = c.router({
       targetFn: z.string(),
       targetArgs: z.string(),
       pool: z.string().optional(),
+      service: z.string().optional(),
     }),
   },
   getJobStatus: {

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -66,6 +66,7 @@ export const jobs = pgTable("jobs", {
     sql`now() + interval '300 seconds'`
   ),
   timeout_interval_seconds: integer("timeout_interval").default(300),
+  service: varchar("service", { length: 1024 }),
 });
 
 export const machines = pgTable("machines", {

--- a/control-plane/src/modules/jobs.test.ts
+++ b/control-plane/src/modules/jobs.test.ts
@@ -12,6 +12,7 @@ describe("createJob", () => {
       targetArgs: mockTargetArgs,
       owner: mockOwner,
       pool: mockPool,
+      service: "testService",
     });
 
     expect(result.id).toBeDefined();
@@ -23,6 +24,7 @@ describe("nextJobs", () => {
   const mockIp = "127.0.0.1";
   const mockLimit = 5;
 
+  // TODO: deprecate this test
   it("should update and return jobs for specified functions", async () => {
     const fnName = `testfn${Date.now()}`;
 
@@ -31,6 +33,7 @@ describe("nextJobs", () => {
       targetArgs: mockTargetArgs,
       owner: mockOwner,
       pool: mockPool,
+      service: null,
     });
 
     const mockFunctions = fnName;
@@ -41,7 +44,39 @@ describe("nextJobs", () => {
       limit: mockLimit,
       machineId: mockMachineId,
       ip: mockIp,
+      service: null,
     });
+
+    expect(result).toStrictEqual([
+      {
+        id,
+        targetArgs: "testTargetArgs",
+        targetFn: fnName,
+      },
+    ]);
+  });
+
+  it("should be able to return spefic jobs per service", async () => {
+    const fnName = `testfn${Date.now()}`;
+
+    const serviceName = `testService${Date.now()}`;
+
+    const { id } = await createJob({
+      targetFn: fnName,
+      targetArgs: mockTargetArgs,
+      owner: mockOwner,
+      service: serviceName,
+    });
+
+    const result = await nextJobs({
+      owner: mockOwner,
+      limit: mockLimit,
+      machineId: mockMachineId,
+      ip: mockIp,
+      service: serviceName,
+    });
+
+    expect(result.length).toBe(1);
 
     expect(result).toStrictEqual([
       {

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -1,21 +1,29 @@
 import { initServer } from "@ts-rest/fastify";
-import crypto from "crypto";
 import { and, eq, sql } from "drizzle-orm";
-import { ulid } from "ulid";
+import fs from "fs";
+import path from "path";
+import util from "util";
+import * as admin from "./admin";
+import * as auth from "./auth";
 import { contract } from "./contract";
 import * as data from "./data";
-import fs from "fs";
-import util from "util";
-import path from "path";
-import * as auth from "./auth";
-import * as admin from "./admin";
-import { QueryResult } from "pg";
 import { createJob, nextJobs } from "./jobs";
 import * as management from "./management";
 
 const readFile = util.promisify(fs.readFile);
 
 const s = initServer();
+
+async function selfHealJobsHack() {
+  await data.db.execute(
+    sql`UPDATE jobs SET status = 'failure' WHERE status = 'running' AND remaining = 0 AND timed_out_at < now()`
+  );
+
+  // make jobs that have failed but still have remaining attempts into pending jobs
+  await data.db.execute(
+    sql`UPDATE jobs SET status = 'pending' WHERE status = 'failure' AND remaining > 0`
+  );
+}
 
 export const router = s.router(contract, {
   getNextJobs: async (request) => {
@@ -49,6 +57,7 @@ export const router = s.router(contract, {
         limit,
         machineId: request.headers["x-machine-id"],
         ip: request.request.ip,
+        service: request.query.service || null,
       });
 
       if (jobs.length === 0) {
@@ -98,9 +107,10 @@ export const router = s.router(contract, {
       };
     }
 
-    const { targetFn, targetArgs, pool } = request.body;
+    const { targetFn, targetArgs, pool, service } = request.body;
 
     const { id } = await createJob({
+      service: service || null,
       targetFn,
       targetArgs,
       owner,
@@ -245,13 +255,3 @@ export const router = s.router(contract, {
     };
   },
 });
-async function selfHealJobsHack() {
-  await data.db.execute(
-    sql`UPDATE jobs SET status = 'failure' WHERE status = 'running' AND remaining = 0 AND timed_out_at < now()`
-  );
-
-  // make jobs that have failed but still have remaining attempts into pending jobs
-  await data.db.execute(
-    sql`UPDATE jobs SET status = 'pending' WHERE status = 'failure' AND remaining > 0`
-  );
-}

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "exit 0",
-    "build": "make sync-api-docs"
+    "build": "exit 0"
   },
   "dependencies": {
     "@differentialhq/core": "3.1.4"

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,9 +1,0 @@
-set -eux
-
-cd ts-core
-make typedoc
-cd ..
-
-cd docs
-make sync-api-docs
-cd ..

--- a/ts-core/docs/classes/Differential.md
+++ b/ts-core/docs/classes/Differential.md
@@ -74,7 +74,7 @@ Initializes a new Differential instance.
 
 #### Defined in
 
-[ts-core/src/Differential.ts:405](https://github.com/differentialHQ/differential/blob/f29b990/ts-core/src/Differential.ts#L405)
+[ts-core/src/Differential.ts:406](https://github.com/differentialHQ/differential/blob/410a22c/ts-core/src/Differential.ts#L406)
 
 ## Methods
 
@@ -118,7 +118,7 @@ console.log(result); // "Hello world"
 
 #### Defined in
 
-[ts-core/src/Differential.ts:528](https://github.com/differentialHQ/differential/blob/f29b990/ts-core/src/Differential.ts#L528)
+[ts-core/src/Differential.ts:529](https://github.com/differentialHQ/differential/blob/410a22c/ts-core/src/Differential.ts#L529)
 
 ▸ **client**\<`T`\>(`service`, `options`): `BackgroundServiceClient`\<`T`\>
 
@@ -160,7 +160,7 @@ console.log(result); // "Hello world"
 
 #### Defined in
 
-[ts-core/src/Differential.ts:532](https://github.com/differentialHQ/differential/blob/f29b990/ts-core/src/Differential.ts#L532)
+[ts-core/src/Differential.ts:533](https://github.com/differentialHQ/differential/blob/410a22c/ts-core/src/Differential.ts#L533)
 
 ___
 
@@ -213,4 +213,4 @@ process.on("beforeExit", async () => {
 
 #### Defined in
 
-[ts-core/src/Differential.ts:504](https://github.com/differentialHQ/differential/blob/f29b990/ts-core/src/Differential.ts#L504)
+[ts-core/src/Differential.ts:505](https://github.com/differentialHQ/differential/blob/410a22c/ts-core/src/Differential.ts#L505)

--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -167,6 +167,7 @@ class PollingAgent {
               .filter((s) => s[1].serviceName === this.service.name)
               .map((s) => s[0])
               .join(","),
+            service: this.service.name,
           },
           headers: {
             authorization: this.authHeader,

--- a/ts-core/src/contract.ts
+++ b/ts-core/src/contract.ts
@@ -20,7 +20,8 @@ export const contract = c.router({
     query: z.object({
       pools: z.string().optional(),
       limit: z.coerce.number().default(1),
-      functions: z.string(),
+      functions: z.string().optional(),
+      service: z.string().optional(),
     }),
     responses: {
       200: z.array(NextJobSchema),
@@ -42,7 +43,8 @@ export const contract = c.router({
     body: z.object({
       targetFn: z.string(),
       targetArgs: z.string(),
-      service: z.string().default("unknown"),
+      pool: z.string().optional(),
+      service: z.string().optional(),
     }),
   },
   getJobStatus: {
@@ -80,7 +82,6 @@ export const contract = c.router({
     body: z.object({
       result: z.string(),
       resultType: z.enum(["resolution", "rejection"]),
-      cacheTTL: z.number().optional(),
     }),
   },
   live: {
@@ -118,9 +119,17 @@ export const contract = c.router({
     }),
     body: z.object({}),
   },
-  getClusters: {
+  getTemporaryToken: {
     method: "GET",
-    path: "/organizations/:organizationId/clusters",
+    path: "/demo/token",
+    responses: {
+      201: z.string(),
+    },
+  },
+  // management routes
+  getClustersForUser: {
+    method: "GET",
+    path: "/clusters",
     headers: z.object({
       authorization: z.string(),
     }),
@@ -129,21 +138,29 @@ export const contract = c.router({
         z.object({
           id: z.string(),
           apiSecret: z.string(),
-          organizationId: z.string(),
           createdAt: z.date(),
-          machineCount: z.number(),
-          lastPingAt: z.date().nullable(),
+          description: z.string().nullable(),
         })
       ),
       401: z.undefined(),
     },
-    pathParams: z.object({
-      organizationId: z.string(),
+  },
+  createClusterForUser: {
+    method: "POST",
+    path: "/clusters",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    responses: {
+      204: z.undefined(),
+    },
+    body: z.object({
+      description: z.string(),
     }),
   },
-  getClusterDetails: {
+  getClusterDetailsForUser: {
     method: "GET",
-    path: "/organizations/:organizationId/clusters/:clusterId",
+    path: "/clusters/:clusterId",
     headers: z.object({
       authorization: z.string(),
     }),
@@ -151,7 +168,6 @@ export const contract = c.router({
       200: z.object({
         id: z.string(),
         apiSecret: z.string(),
-        organizationId: z.string(),
         createdAt: z.date(),
         machines: z.array(
           z.object({
@@ -160,7 +176,6 @@ export const contract = c.router({
             pool: z.string().nullable(),
             lastPingAt: z.date().nullable(),
             ip: z.string().nullable(),
-            organizationId: z.string(),
           })
         ),
         jobs: z.array(
@@ -173,67 +188,9 @@ export const contract = c.router({
         ),
       }),
       401: z.undefined(),
+      404: z.undefined(),
     },
     pathParams: z.object({
-      organizationId: z.string(),
-      clusterId: z.string(),
-    }),
-  },
-  getTemporaryToken: {
-    method: "GET",
-    path: "/demo/token",
-    responses: {
-      201: z.string(),
-    },
-  },
-  putServiceDefinition: {
-    method: "PUT",
-    path: "/organizations/:organizationId/clusters/:clusterId/service-definition",
-    headers: z.object({
-      authorization: z.string(),
-    }),
-    responses: {
-      204: z.undefined(),
-      401: z.undefined(),
-    },
-    pathParams: z.object({
-      organizationId: z.string(),
-      clusterId: z.string(),
-    }),
-    body: z.object({
-      serviceDefinition: z.object({
-        name: z.string(),
-        functions: z.record(
-          z.string(),
-          z.object({
-            name: z.string(),
-            description: z.string().nullable(),
-          })
-        ),
-      }),
-    }),
-  },
-  getServiceDefinition: {
-    method: "GET",
-    path: "/organizations/:organizationId/clusters/:clusterId/service-definition",
-    headers: z.object({
-      authorization: z.string(),
-    }),
-    responses: {
-      200: z.object({
-        name: z.string(),
-        functions: z.record(
-          z.string(),
-          z.object({
-            name: z.string(),
-            description: z.string().nullable(),
-          })
-        ),
-      }),
-      401: z.undefined(),
-    },
-    pathParams: z.object({
-      organizationId: z.string(),
       clusterId: z.string(),
     }),
   },


### PR DESCRIPTION
Clients will now use the `<service>` parameter in `d.client<typeof myService>("<service>")` to create and pull jobs.