### PR TITLE
fix: Render noDataMessage on cluster tables

### DIFF
--- a/admin/app/clusters/[id]/DataTable.tsx
+++ b/admin/app/clusters/[id]/DataTable.tsx
@@ -22,11 +22,8 @@ export const DataTable = <T = any,>({
   noDataMessage?: string;
   columnDef?: ColumnDef<T>[];
 }) => {
-  if (data === undefined || data.length === 0) {
-    return <p className="text-gray-400 mt-2">{noDataMessage}</p>;
-  }
 
-  const keys = Object.keys(data[0]);
+  const keys = data.length > 0 ? Object.keys(data[0]) : [];
 
   const columns: ColumnDef<any>[] =
     columnDef ||
@@ -41,6 +38,7 @@ export const DataTable = <T = any,>({
     getCoreRowModel: getCoreRowModel(),
     manualSorting: true,
   });
+
 
   return (
     <div className="rounded-md border">
@@ -80,7 +78,7 @@ export const DataTable = <T = any,>({
           ) : (
             <TableRow>
               <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
+                  <p className="text-gray-400 mt-2">{noDataMessage}</p>
               </TableCell>
             </TableRow>
           )}

--- a/admin/app/clusters/[id]/DataTable.tsx
+++ b/admin/app/clusters/[id]/DataTable.tsx
@@ -23,7 +23,7 @@ export const DataTable = <T = any,>({
   columnDef?: ColumnDef<T>[];
 }) => {
   if (data === undefined || data.length === 0) {
-    return <div className="text-center">{noDataMessage}</div>;
+    return <p className="text-gray-400 mt-2">{noDataMessage}</p>;
   }
 
   const keys = Object.keys(data[0]);

--- a/admin/app/clusters/[id]/DataTable.tsx
+++ b/admin/app/clusters/[id]/DataTable.tsx
@@ -22,6 +22,10 @@ export const DataTable = <T = any,>({
   noDataMessage?: string;
   columnDef?: ColumnDef<T>[];
 }) => {
+  if (data === undefined || data.length === 0) {
+    return <div className="text-center">{noDataMessage}</div>;
+  }
+
   const keys = Object.keys(data[0]);
 
   const columns: ColumnDef<any>[] =


### PR DESCRIPTION
`noDataMessage` is not currently being rendered.

<img width="990" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/edf12d3f-5543-4e4d-87d5-93caae43f5aa">
