### PR TITLE
feat: Render execution time in admin

### DIFF
--- a/admin/app/clusters/[id]/LiveTables.tsx
+++ b/admin/app/clusters/[id]/LiveTables.tsx
@@ -40,6 +40,7 @@ export function LiveTables({
       createdAt: Date;
       targetFn: string;
       status: string;
+      functionExecutionTime: number | null;
     }[];
   }>({
     machines: [],
@@ -152,8 +153,12 @@ export function LiveTables({
             .map((s) => ({
               "Execution id": s.id,
               Function: s.targetFn,
-              status: s.status,
-              called: formatRelative(new Date(s.createdAt), new Date()),
+              Status: s.status,
+              Called: formatRelative(new Date(s.createdAt), new Date()),
+              "Execution Time":
+                s.functionExecutionTime === null
+                  ? "N/A"
+                  : `${s.functionExecutionTime}ms`,
             }))}
           noDataMessage="No services with function calls have been detected in the cluster lately."
         />

--- a/admin/client/contract.ts
+++ b/admin/client/contract.ts
@@ -21,6 +21,7 @@ export const contract = c.router({
       pools: z.string().optional(),
       limit: z.coerce.number().default(1),
       functions: z.string().optional(),
+      service: z.string().optional(),
     }),
     responses: {
       200: z.array(NextJobSchema),
@@ -43,6 +44,7 @@ export const contract = c.router({
       targetFn: z.string(),
       targetArgs: z.string(),
       pool: z.string().optional(),
+      service: z.string().optional(),
     }),
   },
   getJobStatus: {
@@ -80,6 +82,7 @@ export const contract = c.router({
     body: z.object({
       result: z.string(),
       resultType: z.enum(["resolution", "rejection"]),
+      functionExecutionTime: z.number().optional(),
     }),
   },
   live: {
@@ -182,6 +185,7 @@ export const contract = c.router({
             targetFn: z.string(),
             status: z.string(),
             createdAt: z.date(),
+            functionExecutionTime: z.number().nullable(),
           })
         ),
       }),

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -185,6 +185,7 @@ export const contract = c.router({
             targetFn: z.string(),
             status: z.string(),
             createdAt: z.date(),
+            functionExecutionTime: z.number().nullable(),
           })
         ),
       }),

--- a/control-plane/src/modules/management.ts
+++ b/control-plane/src/modules/management.ts
@@ -78,6 +78,7 @@ export const getClusterDetailsForUser = async ({
         targetFn: string;
         status: string;
         createdAt: Date;
+        functionExecutionTime: number | null;
       }>;
     }
   | undefined
@@ -131,6 +132,7 @@ export const getClusterDetailsForUser = async ({
       targetFn: data.jobs.target_fn,
       status: data.jobs.status,
       createdAt: data.jobs.created_at,
+      functionExecutionTime: data.jobs.function_execution_time_ms,
     })
     .from(data.jobs)
     .where(


### PR DESCRIPTION
Renders execution time from #28 if available

<img width="1429" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/64c1217f-9c9d-4f26-9d73-8eda944466f2">
