### PR TITLE
feat: Pass ServiceDefinition to d.client

### DIFF
--- a/ts-core/src/contract.ts
+++ b/ts-core/src/contract.ts
@@ -190,6 +190,20 @@ export const contract = c.router({
             functionExecutionTime: z.number().nullable(),
           })
         ),
+        services: z.array(
+          z.object({
+            name: z.string(),
+            functions: z.array(
+              z.object({
+                name: z.string(),
+                totalSuccess: z.number(),
+                totalFailure: z.number(),
+                avgExecutionTimeSuccess: z.number().nullable(),
+                avgExecutionTimeFailure: z.number().nullable(),
+              })
+            ),
+          })
+        ),
       }),
       401: z.undefined(),
       404: z.undefined(),

--- a/ts-core/src/tests/e2ee/d.register.ts
+++ b/ts-core/src/tests/e2ee/d.register.ts
@@ -1,0 +1,4 @@
+import {d} from './d';
+import { helloServiceDefinition } from './hello';
+
+export const helloService = d.service(helloServiceDefinition)

--- a/ts-core/src/tests/e2ee/e2ee.test.ts
+++ b/ts-core/src/tests/e2ee/e2ee.test.ts
@@ -1,12 +1,13 @@
 import { d } from "./d";
-import { helloService } from "./hello";
+import { helloService } from "./d.register";
+import { helloServiceDefinition } from "./hello";
 
 describe("e2ee", () => {
   it("should be able to call a service", async () => {
     await helloService.start();
 
     const result = await d
-      .client<typeof helloService>("hello")
+      .client(helloServiceDefinition)
       .greet(["Bob", "Alice"]);
 
     expect(result).toEqual({

--- a/ts-core/src/tests/e2ee/hello.ts
+++ b/ts-core/src/tests/e2ee/hello.ts
@@ -1,5 +1,3 @@
-import { d } from "./d";
-
 export const greet = async (names: string[]) => {
   return {
     result: `Hello ${names.join(", ")}`,
@@ -7,9 +5,9 @@ export const greet = async (names: string[]) => {
   };
 };
 
-export const helloService = d.service({
+export const helloServiceDefinition = {
   name: "hello",
   functions: {
     greet,
   },
-});
+};

--- a/ts-core/src/tests/monolith/d.register.ts
+++ b/ts-core/src/tests/monolith/d.register.ts
@@ -1,0 +1,11 @@
+import { d } from "./d";
+import { dbServiceDefinition } from "./db";
+import { expertServiceDefinition } from "./expert";
+import { facadeServiceDefinition } from "./facade";
+
+(globalThis as any).db = true; // assert this is not registered by others
+
+// Register services
+export const dbService = d.service(dbServiceDefinition);
+export const expertService = d.service(expertServiceDefinition);
+export const facadeService = d.service(facadeServiceDefinition);

--- a/ts-core/src/tests/monolith/db.ts
+++ b/ts-core/src/tests/monolith/db.ts
@@ -1,7 +1,3 @@
-import { d } from "./d";
-
-(globalThis as any).db = true; // assert this is not registered by others
-
 export const getNumberFromDB = async (input1: number, input2: number) => {
   let result = 0;
   for (let i = 0; i < input1 * input2; i++) {
@@ -10,9 +6,10 @@ export const getNumberFromDB = async (input1: number, input2: number) => {
   return result;
 };
 
-export const dbService = d.service({
+export const dbServiceDefinition = {
   name: "db",
   functions: {
     getNumberFromDB,
   },
-});
+}
+

--- a/ts-core/src/tests/monolith/expert.ts
+++ b/ts-core/src/tests/monolith/expert.ts
@@ -1,14 +1,11 @@
-import { d } from "./d";
-
-(globalThis as any).expert = true; // assert this is not registered by others
 
 export const callExpert = async (text: string) => {
   return `Expert says: ${text}`;
 };
 
-export const expertService = d.service({
+export const expertServiceDefinition = {
   name: "expert",
   functions: {
     callExpert,
   },
-});
+};

--- a/ts-core/src/tests/monolith/facade.ts
+++ b/ts-core/src/tests/monolith/facade.ts
@@ -1,5 +1,5 @@
 import { d } from "./d";
-import { expertService } from "./expert";
+import { expertServiceDefinition } from "./expert";
 
 (globalThis as any).expert = true; // assert this is not registered by others
 
@@ -14,8 +14,7 @@ export const cowSay = async ({ cowText }: { cowText: string }) => {
     `;
 };
 
-const expertClient = d.client<typeof expertService>("expert");
-
+const expertClient = d.client(expertServiceDefinition);
 export const interFunctionCall = async ({
   expertText,
   cowText,
@@ -28,10 +27,10 @@ export const interFunctionCall = async ({
   return Promise.all([cowSay({ cowText }), result]);
 };
 
-export const facadeService = d.service({
+export const facadeServiceDefinition = {
   name: "facade",
   functions: {
     cowSay,
     interFunctionCall,
   },
-});
+};

--- a/ts-core/src/tests/monolith/imports.test.ts
+++ b/ts-core/src/tests/monolith/imports.test.ts
@@ -1,0 +1,15 @@
+import { d } from "./d";
+import { dbServiceDefinition } from "./db";
+
+describe("imports", () => {
+  it("should not import a service, if we're just consuming it", async () => {
+    const db = d.client(dbServiceDefinition, { background: true });
+
+    const result = await db.getNumberFromDB(1, 2);
+
+    expect(result.id).toBeDefined();
+
+    // at this point, dbService should not be registered
+    expect((globalThis as any).db).toBeUndefined();
+  });
+});

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -1,25 +1,14 @@
 import { d } from "./d";
-import type { dbService } from "./db";
-import { expertService } from "./expert";
-import { facadeService } from "./facade";
+import { expertServiceDefinition } from "./expert";
+import { facadeServiceDefinition } from "./facade";
+import {expertService, facadeService} from "./d.register";
 
 describe("monolith", () => {
-  it("should not import a service, if we're just consuming it", async () => {
-    const db = d.client<typeof dbService>("db", { background: true });
-
-    const result = await db.getNumberFromDB(1, 2);
-
-    expect(result.id).toBeDefined();
-
-    // at this point, dbService should not be registered
-    expect((globalThis as any).db).toBeUndefined();
-  });
-
   it("should be able to call a service", async () => {
     await expertService.start();
 
     const result = await d
-      .client<typeof expertService>("expert")
+      .client(expertServiceDefinition)
       .callExpert("Can't touch this");
 
     expect(result).toBe("Expert says: Can't touch this");
@@ -27,16 +16,16 @@ describe("monolith", () => {
     await expertService.stop();
   }, 10000);
 
-  it("service client should return the same result as 'call'", async () => {
+  it.only("service client should return the same result as 'call'", async () => {
     await expertService.start();
 
-    const result = await d.call<typeof expertService, "callExpert">(
-      "expert",
+    const result = await d.call(
+      expertServiceDefinition,
       "callExpert",
       "Can't touch this"
     );
 
-    const client = d.client<typeof expertService>("expert");
+    const client = d.client(expertServiceDefinition);
     const clientResult = await client.callExpert("Can't touch this");
 
     expect(clientResult).toBe(result);
@@ -49,7 +38,7 @@ describe("monolith", () => {
     await expertService.start();
 
     const result = await d
-      .client<typeof facadeService>("facade")
+      .client(facadeServiceDefinition)
       .interFunctionCall({
         expertText: "foobar",
         cowText: "foobar",


### PR DESCRIPTION
Update the ergonomics for building a `ServiceClient`, by accepting a reference to the `ServiceDefinition` rather than the _type_ information of `RegisteredService`.

This will allow us to pass configuration information to the client (cache / idempotency key, etc) as required.

Introduce the concept of a `d.register.ts` (our some other name / approach) which is responsible for registering services, this in turn imports the individual `ServiceDefinition` objects allowing us to import `ServiceDefinition` in the client without registering the service.

This changes calling syntax for `d.client` from:
```
import type {expertService} from './export'
const expertClient = d.client<expertService>("expert");
```
to
```
import expertService from './export'
const expertClient = d.client(expertService);
```