### PR TITLE
feat: Initial service metrics with influx DB

### DIFF
--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -17,6 +17,7 @@
     "@babel/preset-env": "^7.22.10",
     "@babel/preset-typescript": "^7.22.11",
     "@fastify/cors": "^8.5.0",
+    "@influxdata/influxdb-client": "^1.33.2",
     "@ts-rest/core": "^3.27.0",
     "@ts-rest/fastify": "^3.27.0",
     "@types/jest": "^29.5.4",

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -213,4 +213,36 @@ export const contract = c.router({
       clusterId: z.string(),
     }),
   },
+  getFunctionMetrics: {
+    method: "GET",
+    path: "/clusters/:clusterId/services/:serviceName/functions/:functionName/metrics",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    responses: {
+      200: z.object({
+        start: z.date(),
+        stop: z.date(),
+        success: z.object({
+          count: z.number(),
+          avgExecutionTime: z.number().nullable(),
+        }),
+        failure: z.object({
+          count: z.number(),
+          avgExecutionTime: z.number().nullable(),
+        }),
+      }),
+      401: z.undefined(),
+      404: z.undefined(),
+    },
+    pathParams: z.object({
+      clusterId: z.string(),
+      serviceName: z.string(),
+      functionName: z.string(),
+    }),
+    query: z.object({
+      start: z.date().optional(),
+      stop: z.date().optional(),
+    })
+  },
 });

--- a/control-plane/src/modules/eventAggregation.test.ts
+++ b/control-plane/src/modules/eventAggregation.test.ts
@@ -1,0 +1,85 @@
+import * as influx from "./influx";
+import * as metrics from "./eventAggregation";
+import { ParameterizedQuery } from "@influxdata/influxdb-client";
+
+jest.mock('./influx')
+; (influx as any)['queryClient'] = {}
+
+const clusterId = "clusterId";
+const serviceName = "serviceName";
+const functionName = "functionName";
+const start = new Date(Date.now() - 86400000);
+const stop = new Date();
+
+
+describe("getFunctionMetrics", () => {
+  it("returns empty metrics response when no rows are returned", async () => {
+    influx.queryClient!.collectRows = jest.fn().mockResolvedValue([]);
+
+    const result = await metrics.getFunctionMetrics(
+      clusterId,
+      serviceName,
+      functionName,
+      start,
+      stop
+    );
+
+    expect(result).toEqual({
+      success: {
+        count: 0,
+        avgExecutionTime: 0,
+      },
+      failure: {
+        count: 0,
+        avgExecutionTime: 0,
+      },
+    });
+  });
+
+  it("correctly build success and failure metrics object", async () => {
+    influx.queryClient!.collectRows = jest.fn().mockImplementation((query: ParameterizedQuery) => {
+      if (query.toString().includes("count()")) {
+        return [
+          {
+            resultType: "resolution",
+            _value: 100,
+          },
+          {
+            resultType: "rejection",
+            _value: 200,
+          },
+        ];
+      }
+
+      return [
+        {
+          resultType: "resolution",
+          _value: 300.00223,
+        },
+        {
+          resultType: "rejection",
+          _value: 400.00023,
+        },
+      ];
+    });
+
+    const result = await metrics.getFunctionMetrics(
+      clusterId,
+      serviceName,
+      functionName,
+      start,
+      stop
+    );
+
+    expect(result).toEqual({
+      success: {
+        count: 100,
+        avgExecutionTime: 300,
+      },
+      failure: {
+        count: 200,
+        avgExecutionTime: 400,
+      },
+    });
+  })
+})

--- a/control-plane/src/modules/eventAggregation.ts
+++ b/control-plane/src/modules/eventAggregation.ts
@@ -1,0 +1,44 @@
+import { INFLUXDB_BUCKET, INFLUXDB_ORG, client } from './influx'
+
+const queryClient = client?.getQueryApi(INFLUXDB_ORG)
+
+type TimeRange = {
+  start: Date
+  stop: Date
+}
+const buildRange = (range: TimeRange) => `range(start: ${range.start.toISOString()}, stop: ${range.stop.toISOString()})`
+
+type JobComposite = {
+  clusterId: string
+  serviceName: string
+  fnName: string 
+}
+const buildJobFilter = (target: JobComposite) => `filter(fn: (r) => r["clusterId"] == "${target.clusterId}" and r["service"] == "${target.serviceName}" and r["function"] == "${target.fnName}")`
+
+// Build a flux query to get the average latency for a given function over a given time range
+export const avgLatencyQuery = (target: JobComposite, range: TimeRange) => `from(bucket: "${INFLUXDB_BUCKET}")
+  |> ${buildRange(range)}
+  |> filter(fn: (r) => r["_measurement"] == "jobResulted")
+  |> ${buildJobFilter(target)}
+  |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
+  |> filter(fn: (r) => r["_field"] == "functionExecutionTime")
+  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)
+`
+
+// Build a flux query to get the total number of calls for a given function over a given time range
+export const resultCountQuery = (target: JobComposite, range: TimeRange) => `from(bucket: "${INFLUXDB_BUCKET}")
+  |> ${buildRange(range)}
+  |> filter(fn: (r) => r["_measurement"] == "jobResulted")
+  |> ${buildJobFilter(target)}
+  |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
+  |> filter(fn: (r) => r["_field"] == "functionExecutionTime")
+  |> count()
+`
+
+export const executeQuery = async (query: string): Promise<any> => {
+  const data = await queryClient?.collectRows(query)
+
+  return data?.map((result) => {
+    return result
+  })
+}

--- a/control-plane/src/modules/events.ts
+++ b/control-plane/src/modules/events.ts
@@ -1,36 +1,32 @@
 import { Point } from "@influxdata/influxdb-client"
-import { INFLUXDB_BUCKET, INFLUXDB_ORG, client } from "./influx"
-
-export const writeClient = client?.getWriteApi(INFLUXDB_ORG, INFLUXDB_BUCKET , 'ms', {
-  ...(process.env['NODE_ENV'] !== 'production' ? { flushInterval: 1000 } : {})
-})
+import { writeClient } from "./influx"
 
 type EventTypes = 'jobCreated' | 'jobResulted' | 'machinePing'
 type Event = {
   type: EventTypes
-  tags?: Record<string, string>
-  intFields?: Record<string, number>
-  stringFields?: Record<string, string>
-  booleanFields?: Record<string, boolean>
+  tags?: Record<string, string | null>
+  intFields?: Record<string, number | null>
+  stringFields?: Record<string, string | null >
+  booleanFields?: Record<string, boolean | null >
 }
 
 export const writeEvent = (event: Event) => {
   const point = new Point(event.type)
 
   event.tags && Object.entries(event.tags).forEach(([key, value]) => {
-    point.tag(key, value)
+    value != undefined && point.tag(key, value)
   })
 
   event.intFields && Object.entries(event.intFields).forEach(([key, value]) => {
-    point.intField(key, value)
+    value !== undefined && point.intField(key, value)
   })
 
   event.stringFields && Object.entries(event.stringFields).forEach(([key, value]) => {
-    point.stringField(key, value)
+    value !== undefined && point.stringField(key, value)
   })
 
   event.booleanFields && Object.entries(event.booleanFields).forEach(([key, value]) => {
-    point.booleanField(key, value)
+    value !== undefined && point.booleanField(key, value)
   })
 
   writeClient?.writePoint(point)

--- a/control-plane/src/modules/events.ts
+++ b/control-plane/src/modules/events.ts
@@ -1,0 +1,38 @@
+import { Point } from "@influxdata/influxdb-client"
+import { INFLUXDB_BUCKET, INFLUXDB_ORG, client } from "./influx"
+
+export const writeClient = client?.getWriteApi(INFLUXDB_ORG, INFLUXDB_BUCKET , 'ms', {
+  ...(process.env['NODE_ENV'] !== 'production' ? { flushInterval: 1000 } : {})
+})
+
+type EventTypes = 'jobCreated' | 'jobResulted' | 'machinePing'
+type Event = {
+  type: EventTypes
+  tags?: Record<string, string>
+  intFields?: Record<string, number>
+  stringFields?: Record<string, string>
+  booleanFields?: Record<string, boolean>
+}
+
+export const writeEvent = (event: Event) => {
+  const point = new Point(event.type)
+
+  event.tags && Object.entries(event.tags).forEach(([key, value]) => {
+    point.tag(key, value)
+  })
+
+  event.intFields && Object.entries(event.intFields).forEach(([key, value]) => {
+    point.intField(key, value)
+  })
+
+  event.stringFields && Object.entries(event.stringFields).forEach(([key, value]) => {
+    point.stringField(key, value)
+  })
+
+  event.booleanFields && Object.entries(event.booleanFields).forEach(([key, value]) => {
+    point.booleanField(key, value)
+  })
+
+  writeClient?.writePoint(point)
+}
+

--- a/control-plane/src/modules/influx.ts
+++ b/control-plane/src/modules/influx.ts
@@ -1,0 +1,24 @@
+import {InfluxDB, Point} from '@influxdata/influxdb-client'
+import { invariant } from '../utils';
+
+let _client: InfluxDB | undefined;
+if (process.env.INFLUXDB_ENABLED) {
+  const token = invariant(
+    process.env.INFLUXDB_TOKEN,
+    "INFLUXDB_TOKEN must be set"
+  );
+
+  const url = invariant(
+    process.env.INFLUXDB_URL,
+    "INFLUXDB_URL must be set"
+  );
+
+  _client = new InfluxDB({url, token})
+} else {
+  console.warn("INFLUXDB_ENABLED is not set, metrics will not be sent to influxdb");
+}
+
+export const INFLUXDB_ORG = 'differential';
+export const INFLUXDB_BUCKET = 'differential';
+export const client = _client;
+

--- a/control-plane/src/modules/influx.ts
+++ b/control-plane/src/modules/influx.ts
@@ -1,7 +1,8 @@
-import {InfluxDB, Point} from '@influxdata/influxdb-client'
+import { InfluxDB } from '@influxdata/influxdb-client'
 import { invariant } from '../utils';
 
-let _client: InfluxDB | undefined;
+// Temporary feature flag for influxdb
+let client: InfluxDB | undefined;
 if (process.env.INFLUXDB_ENABLED) {
   const token = invariant(
     process.env.INFLUXDB_TOKEN,
@@ -13,12 +14,16 @@ if (process.env.INFLUXDB_ENABLED) {
     "INFLUXDB_URL must be set"
   );
 
-  _client = new InfluxDB({url, token})
+  client = new InfluxDB({url, token})
 } else {
   console.warn("INFLUXDB_ENABLED is not set, metrics will not be sent to influxdb");
 }
 
 export const INFLUXDB_ORG = 'differential';
 export const INFLUXDB_BUCKET = 'differential';
-export const client = _client;
+
+export const queryClient = client?.getQueryApi(INFLUXDB_ORG)
+export const writeClient = client?.getWriteApi(INFLUXDB_ORG, INFLUXDB_BUCKET , 'ms', {
+  ...(process.env['NODE_ENV'] !== 'production' ? { flushInterval: 1000 } : {})
+})
 

--- a/control-plane/src/modules/jobs.ts
+++ b/control-plane/src/modules/jobs.ts
@@ -39,7 +39,7 @@ export const createJob = async ({
     type: "jobCreated",
     tags: {
       clusterId: owner.clusterId,
-      ...(service ? { service } : {}),
+      service: service,
       function: targetFn,
     },
     stringFields: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@babel/preset-env": "^7.22.10",
         "@babel/preset-typescript": "^7.22.11",
         "@fastify/cors": "^8.5.0",
+        "@influxdata/influxdb-client": "^1.33.2",
         "@ts-rest/core": "^3.27.0",
         "@ts-rest/fastify": "^3.27.0",
         "@types/jest": "^29.5.4",
@@ -2992,6 +2993,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@influxdata/influxdb-client": {
+      "version": "1.33.2",
+      "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client/-/influxdb-client-1.33.2.tgz",
+      "integrity": "sha512-RT5SxH+grHAazo/YK3UTuWK/frPWRM0N7vkrCUyqVprDgQzlLP+bSK4ak2Jv3QVF/pazTnsxWjvtKZdwskV5Xw=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",


### PR DESCRIPTION
Implements event storage and aggregation with [InfluxDB](https://github.com/influxdata/influxdb) time series database.

- Introduces a `writeEvent` which will publish events using the [InfluxDB node client](https://github.com/influxdata/influxdb-client-js/) which will handle batching / background data writing
- Add events tracking for `jobCreated`, `jobResulted`, `machinePing`
- Creates some basic event aggregation queries for retrieving metrics
- Adds a `getFunctionMetrics` endpoint for retrieving request count and average execution time for a given time period

Please note: This PR should be safe to deploy _without_ provisioning any InfluxDB instance based on the [INFLUXDB_ENABLED](https://github.com/differentialhq/differential/blob/efea7b2eb62092c8591f53f81e2a1417514b7b34/control-plane/src/modules/influx.ts#L6) flag which will gate the feature.