### PR TITLE
fix: Enable json query params

### DIFF
--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -12,7 +12,7 @@ const app = fastify({
 
 const s = initServer();
 
-app.register(s.plugin(router.router));
+app.register(s.plugin(router.router), { jsonQuery: true});
 
 app.register(cors, {
   origin: process.env.CONSOLE_ORIGIN || "https://console.differential.dev",

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -43,6 +43,7 @@ export const router = s.router(contract, {
         machineId: request.headers["x-machine-id"],
         ip: request.request.ip,
         service: request.query.service,
+        definition: request.query.functions ? { functions: request.query.functions } : undefined,
       });
 
       if (jobs.length === 0) {


### PR DESCRIPTION
- Enable [jsonQuery](https://ts-rest.com/docs/api/modules/ts_rest_nest#jsonquery) to allow service definition object to be parsed from params.
- Parse service definition in router.