### PR TITLE
fix: Detect open handles in tests

### DIFF
--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.16",
   "description": "",
   "scripts": {
-    "test": "jest src --setupFiles dotenv/config --forceExit",
+    "test": "jest src --setupFiles dotenv/config --forceExit --detectOpenHandles",
     "test:dev": "jest --watch src --setupFiles dotenv/config --forceExit --onlyChanged",
     "dev": "nodemon src/index.ts",
     "migrations": "npx drizzle-kit generate:pg --schema src/modules/data.ts",

--- a/ts-core/package.json
+++ b/ts-core/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript SDK for differential.dev",
   "main": "bin/index.js",
   "scripts": {
-    "test": "jest ./src --runInBand",
+    "test": "jest ./src --runInBand --forceExit --detectOpenHandles",
     "build": "make update-contract && tsc",
     "clean": "rm -rf ./bin",
     "docs": "typedoc --plugin typedoc-plugin-markdown --out docs --excludePrivate --hideBreadcrumbs --allReflectionsHaveOwnDocument"

--- a/ts-core/src/tests/e2ee/e2ee.test.ts
+++ b/ts-core/src/tests/e2ee/e2ee.test.ts
@@ -15,5 +15,5 @@ describe("e2ee", () => {
     });
 
     await helloService.stop();
-  }, 10000);
+  }, 40000);
 });

--- a/ts-core/src/tests/idempotency/idempotency.test.ts
+++ b/ts-core/src/tests/idempotency/idempotency.test.ts
@@ -22,5 +22,5 @@ describe("Idempotency", () => {
     });
 
     await countService.stop();
-  }, 10000);
+  }, 40000);
 });

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -25,7 +25,7 @@ describe("monolith", () => {
     expect(result).toBe("Expert says: Can't touch this");
 
     await expertService.stop();
-  }, 10000);
+  }, 20000);
 
   it("service client should return the same result as 'call'", async () => {
     await expertService.start();
@@ -42,7 +42,7 @@ describe("monolith", () => {
     expect(clientResult).toBe(result);
 
     await expertService.stop();
-  }, 10000);
+  }, 20000);
 
   it("should be able to call a service from another service", async () => {
     await facadeService.start();
@@ -78,5 +78,5 @@ describe("monolith", () => {
     await expertService.start();
 
     await expertService.stop();
-  });
+  }, 20000);
 });


### PR DESCRIPTION
- Add `--detectOpenHandles` and `--forceExit` in case of hanging tests.
- Bump all jest timeouts