### PR TITLE
fix: Generate random key for idempotency test

### DIFF
--- a/ts-core/src/tests/idempotency/idempotency.test.ts
+++ b/ts-core/src/tests/idempotency/idempotency.test.ts
@@ -7,14 +7,16 @@ describe("Idempotency", () => {
 
     const client = d.client<typeof countService>("hello");
 
-    const result1 = await client.count("hello", { $idempotencyKey: "1" });
+    const key = Math.random().toString(36);
+
+    const result1 = await client.count("hello", { $idempotencyKey: key });
 
     expect(result1).toEqual({
       callCount: 1,
       echo: "hello",
     });
 
-    const result2 = await client.count("hello2", { $idempotencyKey: "1" });
+    const result2 = await client.count("hello2", { $idempotencyKey: key });
 
     expect(result2).toEqual({
       callCount: 1,


### PR DESCRIPTION
I don't believe the current test is actually executing the handler as the same result is being re-used (between runs).

Generate a new key for each test run to ensure that the handler is run the correct number of times.