### PR TITLE
feat: Allow polling wait time configuration

### DIFF
--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -272,7 +272,6 @@ class PollingAgent {
         log("Error polling for next job", { pollResult });
       }
     } finally {
-      log('Finished polling for next job');
       this.pollingForNextJob = false;
     }
   };
@@ -401,6 +400,7 @@ export class Differential {
    * @param options Additional options for the Differential client.
    * @param options.endpoint The endpoint for the Differential cluster. Defaults to https://api.differential.dev.
    * @param options.encryptionKeys An array of encryption keys to use for encrypting and decrypting data. These keys are never sent to the control-plane and allows you to encrypt function arguments and return values. If you do not provide any keys, Differential will not encrypt any data. Encryption has a performance impact on your functions. When you want to rotate keys, you can add new keys to the start of the array. Differential will try to decrypt data with each key in the array until it finds a key that works. Differential will encrypt data with the first key in the array. Each key must be 32 bytes long.
+   * @param options.jobPollWaitTime The amount of time in milliseconds that the client will maintain a connection to the control-plane when polling for jobs. Defaults to 20000ms. If a job is not received within this time, the client will close the connection and try again.
    * @example
    * ```ts
    * // Basic usage
@@ -435,7 +435,7 @@ export class Differential {
       }
     });
 
-    if (options?.jobPollWaitTime !== undefined && 
+    if (options?.jobPollWaitTime !== undefined &&
           options!.jobPollWaitTime! < 5000 ||
           options!.jobPollWaitTime! > 20000
       ) {

--- a/ts-core/src/task-queue.test.ts
+++ b/ts-core/src/task-queue.test.ts
@@ -1,7 +1,5 @@
 import { TaskQueue } from "./task-queue";
 
-jest.useFakeTimers();
-
 describe("TaskQueue", () => {
   const task = () => {
     return {
@@ -10,6 +8,14 @@ describe("TaskQueue", () => {
       resolve: jest.fn(),
     };
   };
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   it("should be able to queue and run tasks", async () => {
     const t = task();

--- a/ts-core/src/tests/e2ee/d.ts
+++ b/ts-core/src/tests/e2ee/d.ts
@@ -8,4 +8,5 @@ if (!process.env.DIFFERENTIAL_API_SECRET) {
 
 export const d = new Differential(process.env.DIFFERENTIAL_API_SECRET, {
   encryptionKeys: [Buffer.from("abcdefghijklmnopqrstuvwxzy123456")],
+  jobPollWaitTime: 5000,
 });

--- a/ts-core/src/tests/e2ee/e2ee.test.ts
+++ b/ts-core/src/tests/e2ee/e2ee.test.ts
@@ -3,6 +3,7 @@ import { helloService } from "./hello";
 
 describe("e2ee", () => {
   it("should be able to call a service", async () => {
+
     await helloService.start();
 
     const result = await d
@@ -15,5 +16,5 @@ describe("e2ee", () => {
     });
 
     await helloService.stop();
-  }, 40000);
+  }, 10000);
 });

--- a/ts-core/src/tests/idempotency/d.ts
+++ b/ts-core/src/tests/idempotency/d.ts
@@ -6,4 +6,6 @@ if (!process.env.DIFFERENTIAL_API_SECRET) {
   throw new Error("Missing env DIFFERENTIAL_API_SECRET");
 }
 
-export const d = new Differential(process.env.DIFFERENTIAL_API_SECRET);
+export const d = new Differential(process.env.DIFFERENTIAL_API_SECRET, {
+  jobPollWaitTime: 5000,
+});

--- a/ts-core/src/tests/idempotency/idempotency.test.ts
+++ b/ts-core/src/tests/idempotency/idempotency.test.ts
@@ -24,5 +24,5 @@ describe("Idempotency", () => {
     });
 
     await countService.stop();
-  }, 40000);
+  }, 10000);
 });

--- a/ts-core/src/tests/monolith/d.ts
+++ b/ts-core/src/tests/monolith/d.ts
@@ -6,4 +6,6 @@ if (!process.env.DIFFERENTIAL_API_SECRET) {
   throw new Error("Missing env DIFFERENTIAL_API_SECRET");
 }
 
-export const d = new Differential(process.env.DIFFERENTIAL_API_SECRET);
+export const d = new Differential(process.env.DIFFERENTIAL_API_SECRET, {
+  jobPollWaitTime: 5000,
+});

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -78,5 +78,5 @@ describe("monolith", () => {
     await expertService.start();
 
     await expertService.stop();
-  }, 10000);
+  }, 20000);
 });

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -25,7 +25,7 @@ describe("monolith", () => {
     expect(result).toBe("Expert says: Can't touch this");
 
     await expertService.stop();
-  }, 20000);
+  }, 10000);
 
   it("service client should return the same result as 'call'", async () => {
     await expertService.start();
@@ -42,7 +42,7 @@ describe("monolith", () => {
     expect(clientResult).toBe(result);
 
     await expertService.stop();
-  }, 20000);
+  }, 10000);
 
   it("should be able to call a service from another service", async () => {
     await facadeService.start();
@@ -71,12 +71,12 @@ describe("monolith", () => {
 
     await facadeService.stop();
     await expertService.stop();
-  }, 20000);
+  }, 10000);
 
   it("should be ok to start the service idempotently", async () => {
     await expertService.start();
     await expertService.start();
 
     await expertService.stop();
-  }, 20000);
+  }, 10000);
 });


### PR DESCRIPTION
Expose the `getNextJobs` `ttl` param via a `jobPollWaitTime` configuration option on `Differential`.

This allows us to configure a lower `ttl` for test cases to **reduce** the likelihood of a dangling request from a previous test case consuming the job created in the next one.