### PR TITLE
fix: Improve polling and shutdown stability

### DIFF
--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -501,6 +501,16 @@ export class Differential {
   }
 
   private async listen(service: ServiceDefinition<any>) {
+    if (
+      this.pollingAgents.find(
+        (p) => p.serviceName === service.name && p.polling
+      )
+    ) {
+      throw new DifferentialError(`Service is already started`, {
+        serviceName: service.name,
+      });
+    }
+
     this.pollingAbortController = new AbortController();
 
     this.pollingClient = createClient(
@@ -517,15 +527,6 @@ export class Differential {
       },
       this.jobPollWaitTime
     );
-
-    if (
-      this.pollingAgents.find(
-        (p) => p.serviceName === service.name && p.polling
-      )
-    ) {
-      log("Polling agent already exists. This is a no-op", { service });
-      return;
-    }
 
     this.pollingAgents.push(pollingAgent);
 

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -47,7 +47,6 @@ describe("monolith", () => {
   }, 10000);
 
   it("should be able to call a service from another service", async () => {
-    await facadeService.start();
     const result = await d
       .client<typeof facadeService>("facade")
       .interFunctionCall({
@@ -74,5 +73,5 @@ describe("monolith", () => {
     await expect(expertService.start()).rejects.toThrowError(
       "Service is already started"
     );
-  }, 20000);
+  });
 });

--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -4,6 +4,16 @@ import { expertService } from "./expert";
 import { facadeService } from "./facade";
 
 describe("monolith", () => {
+  beforeAll(async () => {
+    await expertService.start();
+    await facadeService.start();
+  });
+
+  afterAll(async () => {
+    await expertService.stop();
+    await facadeService.stop();
+  }, 10000);
+
   it("should not import a service, if we're just consuming it", async () => {
     const db = d.client<typeof dbService>("db", { background: true });
 
@@ -16,20 +26,14 @@ describe("monolith", () => {
   });
 
   it("should be able to call a service", async () => {
-    await expertService.start();
-
     const result = await d
       .client<typeof expertService>("expert")
       .callExpert("Can't touch this");
 
     expect(result).toBe("Expert says: Can't touch this");
-
-    await expertService.stop();
   }, 10000);
 
   it("service client should return the same result as 'call'", async () => {
-    await expertService.start();
-
     const result = await d.call<typeof expertService, "callExpert">(
       "expert",
       "callExpert",
@@ -40,14 +44,10 @@ describe("monolith", () => {
     const clientResult = await client.callExpert("Can't touch this");
 
     expect(clientResult).toBe(result);
-
-    await expertService.stop();
   }, 10000);
 
   it("should be able to call a service from another service", async () => {
     await facadeService.start();
-    await expertService.start();
-
     const result = await d
       .client<typeof facadeService>("facade")
       .interFunctionCall({
@@ -68,15 +68,11 @@ describe("monolith", () => {
   "Expert says: foobar",
 ]
 `);
-
-    await facadeService.stop();
-    await expertService.stop();
   }, 10000);
 
-  it("should be ok to start the service idempotently", async () => {
-    await expertService.start();
-    await expertService.start();
-
-    await expertService.stop();
+  it("should not let an already started service start again", async () => {
+    await expect(expertService.start()).rejects.toThrowError(
+      "Service is already started"
+    );
   }, 20000);
 });


### PR DESCRIPTION
- Throw error when a service attempts to start again.
- Scope polling clients to `PollingAgent` and establish `AbortController`s.
- Refactor tests for stability