### PR TITLE
feat: Client metric ingestion endpoint

### DIFF
--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -268,4 +268,26 @@ export const contract = c.router({
       stop: z.date().optional(),
     }),
   },
+  ingestClientEvents: {
+    method: "POST",
+    path: "/metrics",
+    headers: z.object({
+      authorization: z.string(),
+      "x-machine-id": z.string(),
+    }),
+    responses: {
+      204: z.undefined(),
+      401: z.undefined(),
+    },
+    body: z.object({
+      events: z.array(
+        z.object({
+          timestamp: z.coerce.date(),
+          type: z.enum(["machineResourceProbe", "functionInvocation"]),
+          tags: z.record(z.string()).optional(),
+          intFields: z.record(z.number()).optional(),
+        })
+      ),
+    }),
+  }
 });

--- a/control-plane/src/modules/events.ts
+++ b/control-plane/src/modules/events.ts
@@ -1,9 +1,10 @@
 import { Point } from "@influxdata/influxdb-client"
 import { writeClient } from "./influx"
 
-type EventTypes = 'jobCreated' | 'jobResulted' | 'machinePing'
+type EventTypes = 'jobCreated' | 'jobResulted' | 'machinePing' | 'machineResourceProbe' | 'functionInvocation'
 type Event = {
   type: EventTypes
+  timestamp?: Date
   tags?: Record<string, string | null>
   intFields?: Record<string, number | null>
   stringFields?: Record<string, string | null >
@@ -12,6 +13,9 @@ type Event = {
 
 export const writeEvent = (event: Event) => {
   const point = new Point(event.type)
+  if (event.timestamp) {
+    point.timestamp(event.timestamp)
+  }
 
   event.tags && Object.entries(event.tags).forEach(([key, value]) => {
     value != undefined && point.tag(key, value)

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -303,4 +303,28 @@ export const router = s.router(contract, {
       },
     };
   },
+  ingestClientEvents: async (request) => {
+    const owner = await auth.jobOwnerHash(request.headers.authorization);
+
+    if (!owner) {
+      return {
+        status: 401,
+      };
+    }
+
+    request.body.events.forEach((event) => {
+      if (!event.tags) {
+        event.tags = {}
+      }
+
+      event.tags.machineId = request.headers["x-machine-id"]
+      event.tags.clusterId = owner.clusterId
+      writeEvent(event)
+    })
+
+    return {
+      status: 204,
+      body: undefined,
+    };
+  },
 });


### PR DESCRIPTION
Adds a control plane endpoint for ingesting events from the client. This can be used for instrumenting function invocation latency, system resources, etc.

This endpoint simply forwards the events into `influxdb`. In the future, we may want to look at using the [influxdb node client](https://github.com/influxdata/influxdb-client-js/) on the client which will handle batching for us and reduce load on the control plane.

Will be followed by #69 

<img width="1830" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/ed5adc2a-85f7-4d17-b247-ebb0ff29eb18">
