### PR TITLE
feat: Return metrics as time series array

### DIFF
--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -247,13 +247,13 @@ export const contract = c.router({
         start: z.date(),
         stop: z.date(),
         success: z.object({
-          count: z.number(),
-          avgExecutionTime: z.number().nullable(),
+          count: z.array(z.object({timestamp: z.date(), value: z.number()})),
+          avgExecutionTime: z.array(z.object({timestamp: z.date(), value: z.number()})),
         }),
         failure: z.object({
-          count: z.number(),
-          avgExecutionTime: z.number().nullable(),
-        }),
+          count: z.array(z.object({timestamp: z.date(), value: z.number()})),
+          avgExecutionTime: z.array(z.object({timestamp: z.date(), value: z.number()})),
+        })
       }),
       401: z.undefined(),
       404: z.undefined(),
@@ -264,8 +264,8 @@ export const contract = c.router({
       functionName: z.string(),
     }),
     query: z.object({
-      start: z.date().optional(),
-      stop: z.date().optional(),
+      start: z.coerce.date().optional(),
+      stop: z.coerce.date().optional(),
     }),
   },
   ingestClientEvents: {

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -236,9 +236,9 @@ export const contract = c.router({
       clusterId: z.string(),
     }),
   },
-  getServiceMetrics: {
+  getMetrics: {
     method: "GET",
-    path: "/clusters/:clusterId/services/:serviceName/metrics",
+    path: "/clusters/:clusterId/metrics",
     headers: z.object({
       authorization: z.string(),
     }),
@@ -260,12 +260,12 @@ export const contract = c.router({
     },
     pathParams: z.object({
       clusterId: z.string(),
-      serviceName: z.string(),
     }),
     query: z.object({
       start: z.coerce.date().optional(),
       stop: z.coerce.date().optional(),
       functionName: z.string().optional(),
+      serviceName: z.string().optional(),
     }),
   },
   ingestClientEvents: {

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -236,9 +236,9 @@ export const contract = c.router({
       clusterId: z.string(),
     }),
   },
-  getFunctionMetrics: {
+  getServiceMetrics: {
     method: "GET",
-    path: "/clusters/:clusterId/services/:serviceName/functions/:functionName/metrics",
+    path: "/clusters/:clusterId/services/:serviceName/metrics",
     headers: z.object({
       authorization: z.string(),
     }),
@@ -261,11 +261,11 @@ export const contract = c.router({
     pathParams: z.object({
       clusterId: z.string(),
       serviceName: z.string(),
-      functionName: z.string(),
     }),
     query: z.object({
       start: z.coerce.date().optional(),
       stop: z.coerce.date().optional(),
+      functionName: z.string().optional(),
     }),
   },
   ingestClientEvents: {

--- a/control-plane/src/modules/event-aggregation.test.ts
+++ b/control-plane/src/modules/event-aggregation.test.ts
@@ -26,12 +26,12 @@ describe("getFunctionMetrics", () => {
 
     expect(result).toEqual({
       success: {
-        count: 0,
-        avgExecutionTime: 0,
+        count: [],
+        avgExecutionTime: [],
       },
       failure: {
-        count: 0,
-        avgExecutionTime: 0,
+        count: [],
+        avgExecutionTime: [],
       },
     });
   });
@@ -134,20 +134,20 @@ describe("getFunctionMetrics", () => {
         stop
       );
 
-      if (result.success.count !== 2 || result.failure.count !== 2) {
+      if (result.success.count.length !== 2 || result.failure.count.length !== 2) {
         console.log(`Waiting for metrics to be aggregated...`, result);
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
-    } while (result.success.count !== 2 || result.failure.count !== 2);
+    } while (result.success.count.length !== 2 || result.failure.count.length !== 2);
 
     expect(result).toEqual({
       success: {
-        count: 2,
-        avgExecutionTime: 150,
+        count: [expect.objectContaining({ value: 2 })],
+        avgExecutionTime: [expect.objectContaining({ value: 150 })],
       },
       failure: {
-        count: 2,
-        avgExecutionTime: 350,
+        count: [expect.objectContaining({ value: 2 })],
+        avgExecutionTime: [expect.objectContaining({ value: 350 })],
       },
     });
   }, 20000);

--- a/control-plane/src/modules/event-aggregation.test.ts
+++ b/control-plane/src/modules/event-aggregation.test.ts
@@ -134,20 +134,20 @@ describe("getFunctionMetrics", () => {
         functionName
       );
 
-      if (result.success.count.length !== 2 || result.failure.count.length !== 2) {
+      if (result.success.count.length !== 1 || result.failure.count.length !== 1) {
         console.log(`Waiting for metrics to be aggregated...`, result);
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
-    } while (result.success.count.length !== 2 || result.failure.count.length !== 2);
+    } while (result.success.count.length !== 1 || result.failure.count.length !== 1);
 
     expect(result).toEqual({
       success: {
-        count: [expect.objectContaining({ value: 2 })],
-        avgExecutionTime: [expect.objectContaining({ value: 150 })],
+        count: [{ timestamp: expect.anything(), value: 2 }],
+        avgExecutionTime: [{ timestamp: expect.anything(), value: 150 }],
       },
       failure: {
-        count: [expect.objectContaining({ value: 2 })],
-        avgExecutionTime: [expect.objectContaining({ value: 350 })],
+        count: [{ timestamp: expect.anything(), value: 2 }],
+        avgExecutionTime: [{ timestamp: expect.anything(), value: 350 }],
       },
     });
   }, 20000);

--- a/control-plane/src/modules/event-aggregation.test.ts
+++ b/control-plane/src/modules/event-aggregation.test.ts
@@ -19,9 +19,9 @@ describe("getFunctionMetrics", () => {
     const result = await metrics.getFunctionMetrics(
       clusterId,
       serviceName,
-      functionName,
       start,
-      stop
+      stop,
+      functionName
     );
 
     expect(result).toEqual({
@@ -129,9 +129,9 @@ describe("getFunctionMetrics", () => {
       result = await metrics.getFunctionMetrics(
         clusterId,
         serviceName,
-        functionName,
         start,
-        stop
+        stop,
+        functionName
       );
 
       if (result.success.count.length !== 2 || result.failure.count.length !== 2) {

--- a/control-plane/src/modules/event-aggregation.test.ts
+++ b/control-plane/src/modules/event-aggregation.test.ts
@@ -16,13 +16,13 @@ describe("getFunctionMetrics", () => {
     const start = new Date(Date.now() - 86400000);
     const stop = new Date();
 
-    const result = await metrics.getFunctionMetrics(
+    const result = await metrics.getFunctionMetrics({
       clusterId,
       serviceName,
       start,
       stop,
       functionName
-    );
+    });
 
     expect(result).toEqual({
       success: {
@@ -126,13 +126,13 @@ describe("getFunctionMetrics", () => {
     let result;
 
     do {
-      result = await metrics.getFunctionMetrics(
+      result = await metrics.getFunctionMetrics({
         clusterId,
         serviceName,
         start,
         stop,
         functionName
-      );
+      });
 
       if (result.success.count.length !== 1 || result.failure.count.length !== 1) {
         console.log(`Waiting for metrics to be aggregated...`, result);

--- a/control-plane/src/modules/event-aggregation.ts
+++ b/control-plane/src/modules/event-aggregation.ts
@@ -9,46 +9,66 @@ type TimeRange = {
 type JobComposite = {
   clusterId: string;
   serviceName: string;
-  functionName: string;
+  functionName?: string;
 };
 
 // Build a flux query to get the average execution time for a given function over a given time range
 export const resultExecutionTimeQuery = (
   target: JobComposite,
   range: TimeRange
-) => flux`from(bucket: "${INFLUXDB_BUCKET}")
+) => {
+
+  let query = flux`from(bucket: "${INFLUXDB_BUCKET}")
   |> range(start: ${range.start}, stop: ${range.stop})
   |> filter(fn: (r) => r["_measurement"] == "jobResulted")
   |> filter(fn: (r) => r["clusterId"] == "${target.clusterId}")
   |> filter(fn: (r) => r["service"] == "${target.serviceName}")
-  |> filter(fn: (r) => r["function"] == "${target.functionName}")
-  |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
   |> filter(fn: (r) => r["_field"] == "functionExecutionTime")
-  |> aggregateWindow(every: 1m, fn: mean, createEmpty: true)
-`;
+  |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
+`.toString()
+
+  if (target.functionName) {
+    query += flux`|> filter(fn: (r) => r["function"] == "${target.functionName}")
+`.toString()
+  }
+
+  query += flux`|> aggregateWindow(every: 1m, fn: mean, createEmpty: true)
+`.toString()
+
+  return query
+};
 
 // Build a flux query to get the total number of calls for a given function over a given time range
 export const resultCountQuery = (
   target: JobComposite,
   range: TimeRange
-) => flux`from(bucket: "${INFLUXDB_BUCKET}")
+) => {
+  let query = flux`from(bucket: "${INFLUXDB_BUCKET}")
   |> range(start: ${range.start}, stop: ${range.stop})
   |> filter(fn: (r) => r["_measurement"] == "jobResulted")
   |> filter(fn: (r) => r["clusterId"] == "${target.clusterId}")
   |> filter(fn: (r) => r["service"] == "${target.serviceName}")
-  |> filter(fn: (r) => r["function"] == "${target.functionName}")
-  |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
-  |> filter(fn: (r) => r["_field"] == "functionExecutionTime")
+`.toString()
+
+  if (target.functionName) {
+    query += flux`|> filter(fn: (r) => r["function"] == "${target.functionName}")
+`.toString()
+  }
+
+  query += `|> filter(fn: (r) => r["_field"] == "functionExecutionTime")
   |> aggregateWindow(every: 1m, fn: count, createEmpty: true)
-`;
+`.toString()
+
+  return query
+}
 
 type Point = {timestamp: Date, value: number}
 export const getFunctionMetrics = async (
   clusterId: string,
   serviceName: string,
-  functionName: string,
   start: Date,
-  stop: Date
+  stop: Date,
+  functionName?: string
 ): Promise<{
     success: {
       count: Array<Point>
@@ -97,12 +117,12 @@ export const getFunctionMetrics = async (
 
   let metrics = {
     success: {
-      count: [],
-      avgExecutionTime: [],
+      count: [] as Point[],
+      avgExecutionTime: [] as Point[],
     },
     failure: {
-      count: [],
-      avgExecutionTime: [],
+      count: [] as Point[],
+      avgExecutionTime: [] as Point[],
     },
   };
 
@@ -112,12 +132,12 @@ export const getFunctionMetrics = async (
     property: "count" | "avgExecutionTime"
   ): void => {
     if (result["resultType"] === "resolution") {
-      (metrics.success[property] as any).push({
+      metrics.success[property].push({
         timestamp: result["_time"],
         value: Math.round(result._value)
       })
     } else if (result.resultType === "rejection") {
-      (metrics.failure[property] as any).push({
+      metrics.failure[property].push({
         timestamp: result["_time"],
         value: Math.round(result._value)
       })

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -275,25 +275,25 @@ export const router = s.router(contract, {
       body: cluster,
     };
   },
-  getServiceMetrics: async (request) => {
+  getMetrics: async (request) => {
     await routingHelpers.validateManagementAccess(request);
 
     // TODO: Validate serviceName and functionName
     // We don't currently store and service/function names in the database to validate against.
-    const { clusterId, serviceName } = request.params;
-    const { functionName } = request.query;
+    const { clusterId } = request.params;
+    const { functionName, serviceName } = request.query;
 
     // Default to last 24 hours
     const start = request.query.start ?? new Date(Date.now() - 86400000);
     const stop = request.query.stop ?? new Date();
 
-    const result = await metrics.getFunctionMetrics(
+    const result = await metrics.getFunctionMetrics({
       clusterId,
       serviceName,
-      start,
-      stop,
       functionName,
-    );
+      start,
+      stop
+      });
 
     return {
       status: 200,

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -96,7 +96,7 @@ export const router = s.router(contract, {
         resultType,
       },
       intFields: {
-        ...(functionExecutionTime ? { functionExecutionTime } : {}),
+        ...(functionExecutionTime !== undefined ? { functionExecutionTime } : {}),
       },
       stringFields: {
         jobId,
@@ -283,8 +283,8 @@ export const router = s.router(contract, {
     const { clusterId, serviceName, functionName } = request.params;
 
     // Default to last 24 hours
-    const start = request.query.stop ?? new Date(Date.now() - 86400000);
-    const stop = request.query.start ?? new Date();
+    const start = request.query.start ?? new Date(Date.now() - 86400000);
+    const stop = request.query.stop ?? new Date();
 
     const result = await metrics.getFunctionMetrics(
       clusterId,
@@ -299,7 +299,7 @@ export const router = s.router(contract, {
       body: {
         start: start,
         stop: stop,
-        ...result,
+        ...result
       },
     };
   },

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -275,12 +275,13 @@ export const router = s.router(contract, {
       body: cluster,
     };
   },
-  getFunctionMetrics: async (request) => {
+  getServiceMetrics: async (request) => {
     await routingHelpers.validateManagementAccess(request);
 
     // TODO: Validate serviceName and functionName
     // We don't currently store and service/function names in the database to validate against.
-    const { clusterId, serviceName, functionName } = request.params;
+    const { clusterId, serviceName } = request.params;
+    const { functionName } = request.query;
 
     // Default to last 24 hours
     const start = request.query.start ?? new Date(Date.now() - 86400000);
@@ -289,9 +290,9 @@ export const router = s.router(contract, {
     const result = await metrics.getFunctionMetrics(
       clusterId,
       serviceName,
-      functionName,
       start,
-      stop
+      stop,
+      functionName,
     );
 
     return {


### PR DESCRIPTION
Makes a couple changes to the metrics query endpoint ahead of building some metric graphs.

Return metrics as time series array using `aggregateWindow` (currently hard coded to `1m`).
Allow the `functionName` and `serviceName` to be omitted from metric queries, allowing the same endpointy to be used.

Will be followed by initial UI changes in #72 

<img width="1312" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/e486bb93-5992-4803-acef-554c9dbef3f2">
