### PR TITLE
feat: Request count graph

### DIFF
--- a/admin/app/clusters/[clusterId]/services/[serviceName]/ServiceMetrics.tsx
+++ b/admin/app/clusters/[clusterId]/services/[serviceName]/ServiceMetrics.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { client } from '@/client/client';
+import { useAuth } from '@clerk/nextjs';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { AreaChart, Area, Tooltip, XAxis, YAxis, ResponsiveContainer } from 'recharts';
+
+export function ServiceMetrics({
+  token,
+  clusterId,
+  serviceName,
+  functionName,
+}: {
+    token: string;
+    clusterId: string;
+    serviceName: string;
+    functionName?: string;
+}) {
+  const { getToken, isLoaded, isSignedIn } = useAuth();
+
+  const [data, setData] = useState<{
+    success: {
+      count: Array<{
+        timestamp: Date;
+        value: number;
+      }>
+      avgExecutionTime: Array<{
+        timestamp: Date;
+        value: number;
+      }>
+    }
+    failure: {
+      count: Array<{
+        timestamp: Date;
+        value: number;
+      }>
+      avgExecutionTime: Array<{
+        timestamp: Date;
+        value: number;
+      }>
+    }
+
+  }>({
+    success: {
+      count: [],
+      avgExecutionTime: []
+    },
+    failure: {
+      count: [],
+      avgExecutionTime: []
+    }
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const metricsResult = await client.getMetrics({
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+        params: {
+          clusterId: clusterId,
+        },
+        query: {
+          start: new Date(Date.now() - 1000 * 60 * 60),
+          stop: new Date(Date.now()),
+          functionName: functionName,
+          serviceName: serviceName,
+        }
+      });
+
+
+      if (metricsResult.status === 401) {
+        window.location.reload();
+      }
+
+      if (metricsResult.status === 200) {
+        setData({
+          success: metricsResult.body.success,
+          failure: metricsResult.body.failure
+        });
+      } else {
+        toast.error("Failed to fetch service metrics.");
+      }
+    };
+
+    // initial fetch
+    fetchData();
+
+    const interval = setInterval(fetchData, 5000); // Refresh every 5 seconds
+
+    return () => {
+      clearInterval(interval); // Clear the interval when the component unmounts
+    };
+  }, [token, clusterId, serviceName, isLoaded, isSignedIn, getToken]);
+
+  return (
+    <div>
+      <div className="mt-12">
+        <h2 className="text-xl mb-4">Service Calls</h2>
+        <p className="text-gray-400 mb-8">
+          Number of times {serviceName} has been called in the last hour.
+        </p>
+      </div>
+      <div className="rounded-md border" style={{ maxWidth: 1276 }}>
+        <ResponsiveContainer width="100%" height={300}>
+          <AreaChart
+            width={500}
+            height={500}
+            margin={{
+              top: 30,
+              right: 30,
+              left: 30,
+              bottom: 30,
+            }}
+            data={data.success.count}>
+            <Tooltip
+              contentStyle={{ backgroundColor: "#1F2937", color: "#fff" }}
+            />
+            <YAxis
+              dataKey="value"
+            />
+            <XAxis dataKey="timestamp"
+              name="Time"
+              tickFormatter={(time) => {
+                const date = new Date(time);
+                return `${date.getHours()}:${date.getMinutes()}`;
+              }}
+            />
+            <Area type="monotone"
+              dataKey="value"
+              stroke="#8884d8"
+              fill="#8884d8"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};

--- a/admin/app/clusters/[clusterId]/services/[serviceName]/page.tsx
+++ b/admin/app/clusters/[clusterId]/services/[serviceName]/page.tsx
@@ -3,6 +3,7 @@ import { auth } from "@clerk/nextjs";
 import { ServiceLiveTables } from "./ServiceLiveTables";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ServiceMetrics } from "./ServiceMetrics";
 
 export default async function Page({
   params,
@@ -43,6 +44,12 @@ export default async function Page({
         <p className="text-gray-400">Differential Service</p>
         <h1 className="text-2xl font-mono">{params.serviceName}</h1>
       </div>
+
+      <ServiceMetrics
+        token={token}
+        clusterId={params.clusterId}
+        serviceName={params.serviceName}
+      />
 
       <ServiceLiveTables
         token={token}

--- a/admin/package.json
+++ b/admin/package.json
@@ -26,6 +26,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hot-toast": "^2.4.1",
+    "recharts": "^2.10.4",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.22.4"

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -247,13 +247,13 @@ export const contract = c.router({
         start: z.date(),
         stop: z.date(),
         success: z.object({
-          count: z.number(),
-          avgExecutionTime: z.number().nullable(),
+          count: z.array(z.object({timestamp: z.date(), value: z.number()})),
+          avgExecutionTime: z.array(z.object({timestamp: z.date(), value: z.number()})),
         }),
         failure: z.object({
-          count: z.number(),
-          avgExecutionTime: z.number().nullable(),
-        }),
+          count: z.array(z.object({timestamp: z.date(), value: z.number()})),
+          avgExecutionTime: z.array(z.object({timestamp: z.date(), value: z.number()})),
+        })
       }),
       401: z.undefined(),
       404: z.undefined(),
@@ -264,8 +264,8 @@ export const contract = c.router({
       functionName: z.string(),
     }),
     query: z.object({
-      start: z.date().optional(),
-      stop: z.date().optional(),
+      start: z.coerce.date().optional(),
+      stop: z.coerce.date().optional(),
     }),
   },
   ingestClientEvents: {

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -236,9 +236,9 @@ export const contract = c.router({
       clusterId: z.string(),
     }),
   },
-  getServiceMetrics: {
+  getMetrics: {
     method: "GET",
-    path: "/clusters/:clusterId/services/:serviceName/metrics",
+    path: "/clusters/:clusterId/metrics",
     headers: z.object({
       authorization: z.string(),
     }),
@@ -260,12 +260,12 @@ export const contract = c.router({
     },
     pathParams: z.object({
       clusterId: z.string(),
-      serviceName: z.string(),
     }),
     query: z.object({
       start: z.coerce.date().optional(),
       stop: z.coerce.date().optional(),
       functionName: z.string().optional(),
+      serviceName: z.string().optional(),
     }),
   },
   ingestClientEvents: {

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -236,9 +236,9 @@ export const contract = c.router({
       clusterId: z.string(),
     }),
   },
-  getFunctionMetrics: {
+  getServiceMetrics: {
     method: "GET",
-    path: "/clusters/:clusterId/services/:serviceName/functions/:functionName/metrics",
+    path: "/clusters/:clusterId/services/:serviceName/metrics",
     headers: z.object({
       authorization: z.string(),
     }),
@@ -261,11 +261,11 @@ export const contract = c.router({
     pathParams: z.object({
       clusterId: z.string(),
       serviceName: z.string(),
-      functionName: z.string(),
     }),
     query: z.object({
       start: z.coerce.date().optional(),
       stop: z.coerce.date().optional(),
+      functionName: z.string().optional(),
     }),
   },
   ingestClientEvents: {

--- a/control-plane/src/modules/event-aggregation.test.ts
+++ b/control-plane/src/modules/event-aggregation.test.ts
@@ -26,12 +26,12 @@ describe("getFunctionMetrics", () => {
 
     expect(result).toEqual({
       success: {
-        count: 0,
-        avgExecutionTime: 0,
+        count: [],
+        avgExecutionTime: [],
       },
       failure: {
-        count: 0,
-        avgExecutionTime: 0,
+        count: [],
+        avgExecutionTime: [],
       },
     });
   });
@@ -134,20 +134,20 @@ describe("getFunctionMetrics", () => {
         stop
       );
 
-      if (result.success.count !== 2 || result.failure.count !== 2) {
+      if (result.success.count.length !== 2 || result.failure.count.length !== 2) {
         console.log(`Waiting for metrics to be aggregated...`, result);
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
-    } while (result.success.count !== 2 || result.failure.count !== 2);
+    } while (result.success.count.length !== 2 || result.failure.count.length !== 2);
 
     expect(result).toEqual({
       success: {
-        count: 2,
-        avgExecutionTime: 150,
+        count: [expect.objectContaining({ value: 2 })],
+        avgExecutionTime: [expect.objectContaining({ value: 150 })],
       },
       failure: {
-        count: 2,
-        avgExecutionTime: 350,
+        count: [expect.objectContaining({ value: 2 })],
+        avgExecutionTime: [expect.objectContaining({ value: 350 })],
       },
     });
   }, 20000);

--- a/control-plane/src/modules/event-aggregation.test.ts
+++ b/control-plane/src/modules/event-aggregation.test.ts
@@ -134,20 +134,20 @@ describe("getFunctionMetrics", () => {
         functionName
       );
 
-      if (result.success.count.length !== 2 || result.failure.count.length !== 2) {
+      if (result.success.count.length !== 1 || result.failure.count.length !== 1) {
         console.log(`Waiting for metrics to be aggregated...`, result);
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
-    } while (result.success.count.length !== 2 || result.failure.count.length !== 2);
+    } while (result.success.count.length !== 1 || result.failure.count.length !== 1);
 
     expect(result).toEqual({
       success: {
-        count: [expect.objectContaining({ value: 2 })],
-        avgExecutionTime: [expect.objectContaining({ value: 150 })],
+        count: [{ timestamp: expect.anything(), value: 2 }],
+        avgExecutionTime: [{ timestamp: expect.anything(), value: 150 }],
       },
       failure: {
-        count: [expect.objectContaining({ value: 2 })],
-        avgExecutionTime: [expect.objectContaining({ value: 350 })],
+        count: [{ timestamp: expect.anything(), value: 2 }],
+        avgExecutionTime: [{ timestamp: expect.anything(), value: 350 }],
       },
     });
   }, 20000);

--- a/control-plane/src/modules/event-aggregation.test.ts
+++ b/control-plane/src/modules/event-aggregation.test.ts
@@ -19,9 +19,9 @@ describe("getFunctionMetrics", () => {
     const result = await metrics.getFunctionMetrics(
       clusterId,
       serviceName,
-      functionName,
       start,
-      stop
+      stop,
+      functionName
     );
 
     expect(result).toEqual({
@@ -129,9 +129,9 @@ describe("getFunctionMetrics", () => {
       result = await metrics.getFunctionMetrics(
         clusterId,
         serviceName,
-        functionName,
         start,
-        stop
+        stop,
+        functionName
       );
 
       if (result.success.count.length !== 2 || result.failure.count.length !== 2) {

--- a/control-plane/src/modules/event-aggregation.test.ts
+++ b/control-plane/src/modules/event-aggregation.test.ts
@@ -16,13 +16,13 @@ describe("getFunctionMetrics", () => {
     const start = new Date(Date.now() - 86400000);
     const stop = new Date();
 
-    const result = await metrics.getFunctionMetrics(
+    const result = await metrics.getFunctionMetrics({
       clusterId,
       serviceName,
       start,
       stop,
       functionName
-    );
+    });
 
     expect(result).toEqual({
       success: {
@@ -126,13 +126,13 @@ describe("getFunctionMetrics", () => {
     let result;
 
     do {
-      result = await metrics.getFunctionMetrics(
+      result = await metrics.getFunctionMetrics({
         clusterId,
         serviceName,
         start,
         stop,
         functionName
-      );
+      });
 
       if (result.success.count.length !== 1 || result.failure.count.length !== 1) {
         console.log(`Waiting for metrics to be aggregated...`, result);

--- a/control-plane/src/modules/event-aggregation.ts
+++ b/control-plane/src/modules/event-aggregation.ts
@@ -9,46 +9,66 @@ type TimeRange = {
 type JobComposite = {
   clusterId: string;
   serviceName: string;
-  functionName: string;
+  functionName?: string;
 };
 
 // Build a flux query to get the average execution time for a given function over a given time range
 export const resultExecutionTimeQuery = (
   target: JobComposite,
   range: TimeRange
-) => flux`from(bucket: "${INFLUXDB_BUCKET}")
+) => {
+
+  let query = flux`from(bucket: "${INFLUXDB_BUCKET}")
   |> range(start: ${range.start}, stop: ${range.stop})
   |> filter(fn: (r) => r["_measurement"] == "jobResulted")
   |> filter(fn: (r) => r["clusterId"] == "${target.clusterId}")
   |> filter(fn: (r) => r["service"] == "${target.serviceName}")
-  |> filter(fn: (r) => r["function"] == "${target.functionName}")
-  |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
   |> filter(fn: (r) => r["_field"] == "functionExecutionTime")
-  |> aggregateWindow(every: 1m, fn: mean, createEmpty: true)
-`;
+  |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
+`.toString()
+
+  if (target.functionName) {
+    query += flux`|> filter(fn: (r) => r["function"] == "${target.functionName}")
+`.toString()
+  }
+
+  query += flux`|> aggregateWindow(every: 1m, fn: mean, createEmpty: true)
+`.toString()
+
+  return query
+};
 
 // Build a flux query to get the total number of calls for a given function over a given time range
 export const resultCountQuery = (
   target: JobComposite,
   range: TimeRange
-) => flux`from(bucket: "${INFLUXDB_BUCKET}")
+) => {
+  let query = flux`from(bucket: "${INFLUXDB_BUCKET}")
   |> range(start: ${range.start}, stop: ${range.stop})
   |> filter(fn: (r) => r["_measurement"] == "jobResulted")
   |> filter(fn: (r) => r["clusterId"] == "${target.clusterId}")
   |> filter(fn: (r) => r["service"] == "${target.serviceName}")
-  |> filter(fn: (r) => r["function"] == "${target.functionName}")
-  |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
-  |> filter(fn: (r) => r["_field"] == "functionExecutionTime")
+`.toString()
+
+  if (target.functionName) {
+    query += flux`|> filter(fn: (r) => r["function"] == "${target.functionName}")
+`.toString()
+  }
+
+  query += `|> filter(fn: (r) => r["_field"] == "functionExecutionTime")
   |> aggregateWindow(every: 1m, fn: count, createEmpty: true)
-`;
+`.toString()
+
+  return query
+}
 
 type Point = {timestamp: Date, value: number}
 export const getFunctionMetrics = async (
   clusterId: string,
   serviceName: string,
-  functionName: string,
   start: Date,
-  stop: Date
+  stop: Date,
+  functionName?: string
 ): Promise<{
     success: {
       count: Array<Point>
@@ -97,12 +117,12 @@ export const getFunctionMetrics = async (
 
   let metrics = {
     success: {
-      count: [],
-      avgExecutionTime: [],
+      count: [] as Point[],
+      avgExecutionTime: [] as Point[],
     },
     failure: {
-      count: [],
-      avgExecutionTime: [],
+      count: [] as Point[],
+      avgExecutionTime: [] as Point[],
     },
   };
 
@@ -112,12 +132,12 @@ export const getFunctionMetrics = async (
     property: "count" | "avgExecutionTime"
   ): void => {
     if (result["resultType"] === "resolution") {
-      (metrics.success[property] as any).push({
+      metrics.success[property].push({
         timestamp: result["_time"],
         value: Math.round(result._value)
       })
     } else if (result.resultType === "rejection") {
-      (metrics.failure[property] as any).push({
+      metrics.failure[property].push({
         timestamp: result["_time"],
         value: Math.round(result._value)
       })

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -275,25 +275,25 @@ export const router = s.router(contract, {
       body: cluster,
     };
   },
-  getServiceMetrics: async (request) => {
+  getMetrics: async (request) => {
     await routingHelpers.validateManagementAccess(request);
 
     // TODO: Validate serviceName and functionName
     // We don't currently store and service/function names in the database to validate against.
-    const { clusterId, serviceName } = request.params;
-    const { functionName } = request.query;
+    const { clusterId } = request.params;
+    const { functionName, serviceName } = request.query;
 
     // Default to last 24 hours
     const start = request.query.start ?? new Date(Date.now() - 86400000);
     const stop = request.query.stop ?? new Date();
 
-    const result = await metrics.getFunctionMetrics(
+    const result = await metrics.getFunctionMetrics({
       clusterId,
       serviceName,
-      start,
-      stop,
       functionName,
-    );
+      start,
+      stop
+      });
 
     return {
       status: 200,

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -96,7 +96,7 @@ export const router = s.router(contract, {
         resultType,
       },
       intFields: {
-        ...(functionExecutionTime ? { functionExecutionTime } : {}),
+        ...(functionExecutionTime !== undefined ? { functionExecutionTime } : {}),
       },
       stringFields: {
         jobId,
@@ -283,8 +283,8 @@ export const router = s.router(contract, {
     const { clusterId, serviceName, functionName } = request.params;
 
     // Default to last 24 hours
-    const start = request.query.stop ?? new Date(Date.now() - 86400000);
-    const stop = request.query.start ?? new Date();
+    const start = request.query.start ?? new Date(Date.now() - 86400000);
+    const stop = request.query.stop ?? new Date();
 
     const result = await metrics.getFunctionMetrics(
       clusterId,
@@ -299,7 +299,7 @@ export const router = s.router(contract, {
       body: {
         start: start,
         stop: stop,
-        ...result,
+        ...result
       },
     };
   },

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -275,12 +275,13 @@ export const router = s.router(contract, {
       body: cluster,
     };
   },
-  getFunctionMetrics: async (request) => {
+  getServiceMetrics: async (request) => {
     await routingHelpers.validateManagementAccess(request);
 
     // TODO: Validate serviceName and functionName
     // We don't currently store and service/function names in the database to validate against.
-    const { clusterId, serviceName, functionName } = request.params;
+    const { clusterId, serviceName } = request.params;
+    const { functionName } = request.query;
 
     // Default to last 24 hours
     const start = request.query.start ?? new Date(Date.now() - 86400000);
@@ -289,9 +290,9 @@ export const router = s.router(contract, {
     const result = await metrics.getFunctionMetrics(
       clusterId,
       serviceName,
-      functionName,
       start,
-      stop
+      stop,
+      functionName,
     );
 
     return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hot-toast": "^2.4.1",
+        "recharts": "^2.10.4",
         "tailwind-merge": "^2.2.0",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.22.4"
@@ -4780,6 +4781,60 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.2.tgz",
+      "integrity": "sha512-WAIEVlOCdd/NKRYTsqCpOMHQHemKBEINf8YXMYOtXH0GA7SY0dqMB78P3Uhgfy+4X+/Mlw2wDtlETkN6kQUCMA=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -7418,6 +7473,116 @@
         "type": "^1.0.1"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7500,6 +7665,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -7686,6 +7856,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
       }
     },
     "node_modules/dot-case": {
@@ -8929,8 +9107,7 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -9044,6 +9221,14 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -10385,6 +10570,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip": {
@@ -12579,8 +12772,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -15556,7 +15748,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15566,8 +15757,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/protocols": {
       "version": "2.0.1",
@@ -15715,6 +15905,40 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-smooth": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.5.tgz",
+      "integrity": "sha512-BMP2Ad42tD60h0JW6BFaib+RJuV5dsXJK9Baxiv/HlNFjvRLqA9xrNKxVWnUIZPQfzUwGXIlU/dSYLU+54YGQA==",
+      "dependencies": {
+        "fast-equals": "^5.0.0",
+        "react-transition-group": "2.9.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "dependencies": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0",
+        "react-dom": ">=15.0.0"
+      }
     },
     "node_modules/read": {
       "version": "2.1.0",
@@ -16073,6 +16297,42 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.10.4.tgz",
+      "integrity": "sha512-/Q7/wdf8bW91lN3NEeCjL9RWfaiXQViJFgdnas4Eix/I8B9HAI3tHHK/CW/zDfgRMh4fzW1zlfjoz1IAapLO1Q==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "^16.10.2",
+        "react-smooth": "^2.0.5",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -17617,6 +17877,11 @@
         "next-tick": "1"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -18853,6 +19118,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.8.1",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.8.1.tgz",
+      "integrity": "sha512-T8cXN8D6J9wEtDEHLiXcgrOE5gyKR39s9fCFTGmcOfqDrT8m2XQLt+2p/n007uxEMRvCDH7GYYqy4vV7GIcGhw==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vscode-oniguruma": {


### PR DESCRIPTION
Adds an initial graph of service calls based on the changes in #71  and using [Recharts](https://recharts.org/en-US/api).

Built into a new comment `ServiceMetrics` which will eventually house controls for filtering, etc.

<img width="1312" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/e59207f2-56a0-4bca-9f97-ced70e1f47ac">
