### PR TITLE
fix: Use getToken for retrieving auth token

### DIFF
--- a/admin/app/clusters/[clusterId]/services/[serviceName]/ServiceMetrics.tsx
+++ b/admin/app/clusters/[clusterId]/services/[serviceName]/ServiceMetrics.tsx
@@ -7,12 +7,10 @@ import toast from 'react-hot-toast';
 import { AreaChart, Area, Tooltip, XAxis, YAxis, ResponsiveContainer } from 'recharts';
 
 export function ServiceMetrics({
-  token,
   clusterId,
   serviceName,
   functionName,
 }: {
-    token: string;
     clusterId: string;
     serviceName: string;
     functionName?: string;
@@ -56,7 +54,7 @@ export function ServiceMetrics({
     const fetchData = async () => {
       const metricsResult = await client.getMetrics({
         headers: {
-          authorization: `Bearer ${token}`,
+          authorization: `Bearer ${await getToken()}`,
         },
         params: {
           clusterId: clusterId,
@@ -92,9 +90,9 @@ export function ServiceMetrics({
     return () => {
       clearInterval(interval); // Clear the interval when the component unmounts
     };
-  }, [token, clusterId, serviceName, isLoaded, isSignedIn, getToken]);
+  }, [clusterId, serviceName, isLoaded, isSignedIn, getToken]);
 
-  return (
+  return data.success.count.length > 0 ? (
     <div>
       <div className="mt-12">
         <h2 className="text-xl mb-4">Service Calls</h2>
@@ -103,38 +101,38 @@ export function ServiceMetrics({
         </p>
       </div>
       <div className="rounded-md border" style={{ maxWidth: 1276 }}>
-        <ResponsiveContainer width="100%" height={300}>
-          <AreaChart
-            width={500}
-            height={500}
-            margin={{
-              top: 30,
-              right: 30,
-              left: 30,
-              bottom: 30,
-            }}
-            data={data.success.count}>
-            <Tooltip
-              contentStyle={{ backgroundColor: "#1F2937", color: "#fff" }}
-            />
-            <YAxis
-              dataKey="value"
-            />
-            <XAxis dataKey="timestamp"
-              name="Time"
-              tickFormatter={(time) => {
-                const date = new Date(time);
-                return `${date.getHours()}:${date.getMinutes()}`;
+          <ResponsiveContainer width="100%" height={300}>
+            <AreaChart
+              width={500}
+              height={500}
+              margin={{
+                top: 30,
+                right: 30,
+                left: 30,
+                bottom: 30,
               }}
-            />
-            <Area type="monotone"
-              dataKey="value"
-              stroke="#8884d8"
-              fill="#8884d8"
-            />
-          </AreaChart>
-        </ResponsiveContainer>
+              data={data.success.count}>
+              <Tooltip
+                contentStyle={{ backgroundColor: "#1F2937", color: "#fff" }}
+              />
+              <YAxis
+                dataKey="value"
+              />
+              <XAxis dataKey="timestamp"
+                name="Time"
+                tickFormatter={(time) => {
+                  const date = new Date(time);
+                  return `${date.getHours()}:${date.getMinutes()}`;
+                }}
+              />
+              <Area type="monotone"
+                dataKey="value"
+                stroke="#8884d8"
+                fill="#8884d8"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
       </div>
     </div>
-  );
+  ) : null;
 };

--- a/admin/app/clusters/[clusterId]/services/[serviceName]/page.tsx
+++ b/admin/app/clusters/[clusterId]/services/[serviceName]/page.tsx
@@ -46,7 +46,6 @@ export default async function Page({
       </div>
 
       <ServiceMetrics
-        token={token}
         clusterId={params.clusterId}
         serviceName={params.serviceName}
       />


### PR DESCRIPTION
A couple small fixes for the metric graph view #72 
- Use [getToken()](https://clerk.com/docs/references/backend/sessions/get-token) to ensure the auth token remains fresh. Currently this expires after a couple retries.
- Hide graph if no data is available (in the future we can show a nicer placeholder but currently it just looks broken)