### PR TITLE
feat: Write job activity to influxdb

### DIFF
--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -58,7 +58,7 @@ export const contract = c.router({
       targetFn: z.string(),
       targetArgs: z.string(),
       pool: z.string().optional(),
-      service: z.string().optional(),
+      service: z.string().default("unknown"),
       idempotencyKey: z.string().optional(),
     }),
   },
@@ -247,13 +247,17 @@ export const contract = c.router({
         start: z.date(),
         stop: z.date(),
         success: z.object({
-          count: z.array(z.object({timestamp: z.date(), value: z.number()})),
-          avgExecutionTime: z.array(z.object({timestamp: z.date(), value: z.number()})),
+          count: z.array(z.object({ timestamp: z.date(), value: z.number() })),
+          avgExecutionTime: z.array(
+            z.object({ timestamp: z.date(), value: z.number() })
+          ),
         }),
         failure: z.object({
-          count: z.array(z.object({timestamp: z.date(), value: z.number()})),
-          avgExecutionTime: z.array(z.object({timestamp: z.date(), value: z.number()})),
-        })
+          count: z.array(z.object({ timestamp: z.date(), value: z.number() })),
+          avgExecutionTime: z.array(
+            z.object({ timestamp: z.date(), value: z.number() })
+          ),
+        }),
       }),
       401: z.undefined(),
       404: z.undefined(),
@@ -289,5 +293,5 @@ export const contract = c.router({
         })
       ),
     }),
-  }
+  },
 });

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -81,7 +81,7 @@ export const jobs = pgTable(
       sql`now() + interval '300 seconds'`
     ),
     timeout_interval_seconds: integer("timeout_interval").default(300),
-    service: varchar("service", { length: 1024 }),
+    service: varchar("service", { length: 1024 }).notNull(),
   },
   (table) => ({
     pk: primaryKey(table.owner_hash, table.target_fn, table.idempotency_key),

--- a/control-plane/src/modules/event-aggregation.ts
+++ b/control-plane/src/modules/event-aggregation.ts
@@ -17,79 +17,75 @@ export const resultExecutionTimeQuery = (
   target: JobComposite,
   range: TimeRange
 ) => {
-
   let query = flux`from(bucket: "${INFLUXDB_BUCKET}")
   |> range(start: ${range.start}, stop: ${range.stop})
   |> filter(fn: (r) => r["_measurement"] == "jobResulted")
   |> filter(fn: (r) => r["clusterId"] == "${target.clusterId}")
   |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
   |> filter(fn: (r) => r["_field"] == "functionExecutionTime")
-`.toString()
+`.toString();
 
   if (target.serviceName) {
     query += flux`|> filter(fn: (r) => r["service"] == "${target.serviceName}")
-`.toString()
+`.toString();
   }
 
   if (target.functionName) {
-    query += flux`|> filter(fn: (r) => r["function"] == "${target.functionName}")
-`.toString()
+    query +=
+      flux`|> filter(fn: (r) => r["function"] == "${target.functionName}")
+`.toString();
   }
 
   query += flux`|> aggregateWindow(every: 1m, fn: mean, createEmpty: true)
-`.toString()
+`.toString();
 
-  return query
+  return query;
 };
 
 // Build a flux query to get the total number of calls for a given function over a given time range
-export const resultCountQuery = (
-  target: JobComposite,
-  range: TimeRange
-) => {
+export const resultCountQuery = (target: JobComposite, range: TimeRange) => {
   let query = flux`from(bucket: "${INFLUXDB_BUCKET}")
   |> range(start: ${range.start}, stop: ${range.stop})
   |> filter(fn: (r) => r["_measurement"] == "jobResulted")
   |> filter(fn: (r) => r["clusterId"] == "${target.clusterId}")
   |> filter(fn: (r) => r["resultType"] == "resolution" or r["resultType"] == "rejection")
   |> filter(fn: (r) => r["_field"] == "functionExecutionTime")
-`.toString()
+`.toString();
 
   if (target.serviceName) {
     query += flux`|> filter(fn: (r) => r["service"] == "${target.serviceName}")
-`.toString()
+`.toString();
   }
 
   if (target.functionName) {
-    query += flux`|> filter(fn: (r) => r["function"] == "${target.functionName}")
-`.toString()
+    query +=
+      flux`|> filter(fn: (r) => r["function"] == "${target.functionName}")
+`.toString();
   }
 
   query += `|> aggregateWindow(every: 1m, fn: count, createEmpty: true)
-`.toString()
+`.toString();
 
-  return query
-}
+  return query;
+};
 
-type Point = {timestamp: Date, value: number}
-export const getFunctionMetrics = async (
-  query: {
-    clusterId: string,
-    serviceName?: string,
-    functionName?: string
-    start: Date,
-    stop: Date,
-  }
-): Promise<{
-    success: {
-      count: Array<Point>
-      avgExecutionTime: Array<Point>;
-    };
-    failure: {
-      count: Array<Point>
-      avgExecutionTime: Array<Point>;
-    };
-  }> => {
+type Point = { timestamp: Date; value: number };
+export const getFunctionMetrics = async (query: {
+  clusterId: string;
+  serviceName?: string;
+  functionName?: string;
+  start: Date;
+  stop: Date;
+}): Promise<{
+  success: {
+    count: Array<Point>;
+    avgExecutionTime: Array<Point>;
+  };
+  failure: {
+    count: Array<Point>;
+    avgExecutionTime: Array<Point>;
+  };
+}> => {
   // Temporarily throw an error if the client is not initialized / enabled
   // QueryClient can be non-optinal once the influxdb flag is removed
   if (!queryClient) {
@@ -147,17 +143,58 @@ export const getFunctionMetrics = async (
     if (result["resultType"] === "resolution") {
       metrics.success[property].push({
         timestamp: result["_time"],
-        value: Math.round(result._value)
-      })
+        value: Math.round(result._value),
+      });
     } else if (result.resultType === "rejection") {
       metrics.failure[property].push({
         timestamp: result["_time"],
-        value: Math.round(result._value)
-      })
+        value: Math.round(result._value),
+      });
     }
   };
   executionCount.forEach((x: any) => processResults(x, "count"));
   executionTime.forEach((x: any) => processResults(x, "avgExecutionTime"));
 
   return metrics;
+};
+
+export const getJobActivityByJobId = async (params: {
+  clusterId: string;
+  jobId: string;
+}) => {
+  let query = flux`from(bucket: "${INFLUXDB_BUCKET}")
+  |> range(start: -7d)
+  |> filter(fn: (r) => r["_measurement"] == "jobActivity")
+  |> filter(fn: (r) => r["_field"] == "meta")
+  |> filter(fn: (r) => r["clusterId"] == "${params.clusterId}")
+  |> filter(fn: (r) => r["jobId"] == "${params.jobId}")
+`.toString();
+
+  type JobActivity = {
+    _field: string;
+    _measurement: string;
+    _start: string;
+    _stop: string;
+    _time: string;
+    _value: string;
+    clusterId: string; // or number, depending on the actual type
+    jobId: string; // or number, depending on the actual type
+    result: string;
+    service?: string;
+    machineId?: string;
+    table: number;
+    type: string;
+  };
+
+  const result: JobActivity[] = (await queryClient?.collectRows(query)) ?? [];
+
+  return result.map((point) => ({
+    timestamp: point._time,
+    type: point.type,
+    service: point.service,
+    meta: point._value,
+    clusterId: point.clusterId,
+    jobId: point.jobId,
+    machineId: point.machineId,
+  }));
 };

--- a/control-plane/src/modules/events.ts
+++ b/control-plane/src/modules/events.ts
@@ -6,7 +6,9 @@ type EventTypes =
   | "jobResulted"
   | "machinePing"
   | "machineResourceProbe"
-  | "functionInvocation";
+  | "functionInvocation"
+  | "jobActivity";
+
 type Event = {
   type: EventTypes;
   timestamp?: Date;
@@ -43,7 +45,28 @@ export const writeEvent = (event: Event) => {
       value !== undefined && point.booleanField(key, value);
     });
 
-  console.log("writing event", point.toLineProtocol());
-
   writeClient?.writePoint(point);
+};
+
+export const writeJobActivity = (params: {
+  service: string;
+  clusterId: string;
+  jobId: string;
+  type: string;
+  meta: object;
+  machineId?: string;
+}) => {
+  writeEvent({
+    type: "jobActivity",
+    tags: {
+      jobId: params.jobId,
+      type: params.type,
+      clusterId: params.clusterId,
+      service: params.service,
+      machineId: params.machineId || null,
+    },
+    stringFields: {
+      meta: JSON.stringify(params.meta),
+    },
+  });
 };

--- a/control-plane/src/modules/jobs.ts
+++ b/control-plane/src/modules/jobs.ts
@@ -3,7 +3,7 @@ import { ulid } from "ulid";
 import * as cron from "./cron";
 import * as data from "./data";
 import { backgrounded } from "./util";
-import { writeEvent } from "./events";
+import { writeEvent, writeJobActivity } from "./events";
 import {
   ServiceDefinition,
   storeServiceDefinitionBG,
@@ -17,7 +17,7 @@ export const createJob = async ({
   pool,
   idempotencyKey,
 }: {
-  service: string | null;
+  service: string;
   targetFn: string;
   targetArgs: string;
   owner: { clusterId: string };
@@ -49,6 +49,17 @@ export const createJob = async ({
     },
     stringFields: {
       jobId: jobId,
+    },
+  });
+
+  writeJobActivity({
+    service,
+    clusterId: owner.clusterId,
+    jobId,
+    type: "RECEIVED_BY_CONTROL_PLANE",
+    meta: {
+      targetFn,
+      targetArgs,
     },
   });
 
@@ -102,6 +113,20 @@ export const nextJobs = async ({
     targetArgs: row.target_args as string,
   }));
 
+  jobs.forEach((job) => {
+    writeJobActivity({
+      service,
+      clusterId: owner.clusterId,
+      jobId: job.id,
+      type: "RECEIVED_BY_MACHINE",
+      meta: {
+        targetFn: job.targetFn,
+        targetArgs: job.targetArgs,
+      },
+      machineId,
+    });
+  });
+
   return jobs;
 };
 
@@ -114,6 +139,7 @@ export const getJobStatus = async ({
 }) => {
   const [job] = await data.db
     .select({
+      service: data.jobs.service,
       status: data.jobs.status,
       result: data.jobs.result,
       resultType: data.jobs.result_type,
@@ -122,6 +148,18 @@ export const getJobStatus = async ({
     .where(
       and(eq(data.jobs.id, jobId), eq(data.jobs.owner_hash, owner.clusterId))
     );
+
+  if (job) {
+    writeJobActivity({
+      service: job.service,
+      clusterId: owner.clusterId,
+      jobId,
+      type: "JOB_STATUS_REQUESTED",
+      meta: {
+        status: job.status,
+      },
+    });
+  }
 
   return job;
 };
@@ -149,11 +187,72 @@ const storeMachineInfoBG = backgrounded(async function storeMachineInfo(
     });
 });
 
+export async function persistJobResult({
+  result,
+  resultType,
+  functionExecutionTime,
+  jobId,
+  owner,
+  machineId,
+}: {
+  result: string;
+  resultType: "resolution" | "rejection";
+  functionExecutionTime: number | undefined;
+  jobId: string;
+  owner: { organizationId: string | null; clusterId: string };
+  machineId: string;
+}) {
+  const updateResult = await data.db
+    .update(data.jobs)
+    .set({
+      result,
+      result_type: resultType,
+      resulted_at: sql`now()`,
+      function_execution_time_ms: functionExecutionTime,
+      status: "success",
+    })
+    .where(
+      and(eq(data.jobs.id, jobId), eq(data.jobs.owner_hash, owner.clusterId))
+    )
+    .returning({ service: data.jobs.service, function: data.jobs.target_fn });
+
+  writeEvent({
+    type: "jobResulted",
+    tags: {
+      clusterId: owner.clusterId,
+      service: updateResult[0]?.service,
+      function: updateResult[0]?.function,
+      resultType,
+    },
+    intFields: {
+      ...(functionExecutionTime !== undefined ? { functionExecutionTime } : {}),
+    },
+    stringFields: {
+      jobId,
+    },
+  });
+
+  writeJobActivity({
+    service: updateResult[0]?.service,
+    clusterId: owner.clusterId,
+    jobId,
+    type: "RESULT_SENT_TO_CONTROL_PLANE",
+    machineId,
+    meta: {
+      targetFn: updateResult[0]?.function,
+      resultType,
+      result,
+    },
+  });
+}
+
 export async function selfHealJobs() {
+  // TODO: writeJobActivity
   await data.db.execute(
     sql`UPDATE jobs SET status = 'failure' WHERE status = 'running' AND remaining = 0 AND timed_out_at < now()`
   );
 
+  // TODO: writeJobActivity
   // make jobs that have failed but still have remaining attempts into pending jobs
   await data.db.execute(
     sql`UPDATE jobs SET status = 'pending' WHERE status = 'failure' AND remaining > 0`

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -5,13 +5,12 @@ import path from "path";
 import util from "util";
 import * as admin from "./admin";
 import * as auth from "./auth";
+import * as jobs from "./jobs";
 import { contract } from "./contract";
 import * as data from "./data";
-import { createJob, getJobStatus, nextJobs } from "./jobs";
-import * as management from "./management";
 import * as metrics from "./event-aggregation";
 import { writeEvent } from "./events";
-import * as serviceDefinitions from "./service-definitions";
+import * as management from "./management";
 import * as routingHelpers from "./routing-helpers";
 
 const readFile = util.promisify(fs.readFile);
@@ -30,7 +29,7 @@ export const router = s.router(contract, {
 
     const limit = request.body.limit ?? 1;
 
-    let jobs: {
+    let collection: {
       id: string;
       targetFn: string;
       targetArgs: string;
@@ -39,7 +38,7 @@ export const router = s.router(contract, {
     const start = Date.now();
 
     do {
-      jobs = await nextJobs({
+      collection = await jobs.nextJobs({
         owner,
         limit,
         machineId: request.headers["x-machine-id"],
@@ -51,14 +50,14 @@ export const router = s.router(contract, {
         },
       });
 
-      if (jobs.length === 0) {
+      if (collection.length === 0) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
-    } while (jobs.length === 0 && Date.now() - start < request.body.ttl);
+    } while (collection.length === 0 && Date.now() - start < request.body.ttl);
 
     return {
       status: 200,
-      body: jobs,
+      body: collection,
     };
   },
   persistJobResult: async (request) => {
@@ -73,34 +72,13 @@ export const router = s.router(contract, {
     const { jobId } = request.params;
     const { result, resultType, functionExecutionTime } = request.body;
 
-    const updateResult = await data.db
-      .update(data.jobs)
-      .set({
-        result,
-        result_type: resultType,
-        resulted_at: sql`now()`,
-        function_execution_time_ms: functionExecutionTime,
-        status: "success",
-      })
-      .where(
-        and(eq(data.jobs.id, jobId), eq(data.jobs.owner_hash, owner.clusterId))
-      )
-      .returning({ service: data.jobs.service, function: data.jobs.target_fn });
-
-    writeEvent({
-      type: "jobResulted",
-      tags: {
-        clusterId: owner.clusterId,
-        service: updateResult[0]?.service,
-        function: updateResult[0]?.function,
-        resultType,
-      },
-      intFields: {
-        ...(functionExecutionTime !== undefined ? { functionExecutionTime } : {}),
-      },
-      stringFields: {
-        jobId,
-      },
+    await jobs.persistJobResult({
+      result,
+      resultType,
+      functionExecutionTime,
+      jobId,
+      owner,
+      machineId: request.headers["x-machine-id"] as string,
     });
 
     return {
@@ -120,8 +98,8 @@ export const router = s.router(contract, {
     const { targetFn, targetArgs, pool, service, idempotencyKey } =
       request.body;
 
-    const { id } = await createJob({
-      service: service || null,
+    const { id } = await jobs.createJob({
+      service,
       targetFn,
       targetArgs,
       owner,
@@ -147,12 +125,12 @@ export const router = s.router(contract, {
 
     const { jobId } = request.params;
 
-    let job: Awaited<ReturnType<typeof getJobStatus>>;
+    let job: Awaited<ReturnType<typeof jobs.getJobStatus>>;
 
     const start = Date.now();
 
     do {
-      job = await getJobStatus({
+      job = await jobs.getJobStatus({
         jobId,
         owner,
       });
@@ -292,15 +270,15 @@ export const router = s.router(contract, {
       serviceName,
       functionName,
       start,
-      stop
-      });
+      stop,
+    });
 
     return {
       status: 200,
       body: {
         start: start,
         stop: stop,
-        ...result
+        ...result,
       },
     };
   },
@@ -315,13 +293,13 @@ export const router = s.router(contract, {
 
     request.body.events.forEach((event) => {
       if (!event.tags) {
-        event.tags = {}
+        event.tags = {};
       }
 
-      event.tags.machineId = request.headers["x-machine-id"]
-      event.tags.clusterId = owner.clusterId
-      writeEvent(event)
-    })
+      event.tags.machineId = request.headers["x-machine-id"];
+      event.tags.clusterId = owner.clusterId;
+      writeEvent(event);
+    });
 
     return {
       status: 204,


### PR DESCRIPTION
This change exposes a `writeJobActivity` util which will send job based data into influxdb as a `_measurement="jobActivity"`. Plus, minor refactoring to bring all jobs module code into jobs.ts.