### PR TITLE
feat: Add caching

### DIFF
--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -32,6 +32,7 @@
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0",
     "msgpackr": "^1.10.1",
+    "node-cache": "^5.1.2",
     "nodemon": "^3.0.1",
     "pg": "^8.11.2",
     "ts-node": "^10.9.1",

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import {
   integer,
@@ -10,7 +11,6 @@ import {
 } from "drizzle-orm/pg-core";
 import { Pool } from "pg";
 import { invariant } from "../utilities/invariant";
-import { sql } from "drizzle-orm";
 
 const connectionString = invariant(
   process.env.DATABASE_URL,
@@ -60,6 +60,7 @@ export const jobs = pgTable(
     target_fn: varchar("target_fn", { length: 1024 }).notNull(),
     target_args: text("target_args").notNull(),
     idempotency_key: varchar("idempotency_key", { length: 1024 }).notNull(),
+    cache_key: varchar("cache_key", { length: 1024 }),
     status: text("status", {
       enum: ["pending", "running", "success", "failure"],
     }).notNull(),

--- a/control-plane/src/modules/jobs.ts
+++ b/control-plane/src/modules/jobs.ts
@@ -11,7 +11,7 @@ import {
 import { backgrounded } from "./util";
 
 const createJobStrategies = {
-  idempotece: async ({
+  idempotence: async ({
     service,
     targetFn,
     targetArgs,
@@ -203,7 +203,7 @@ export const createJob = async ({
 }) => {
   // TODO: refactor this
   if (idempotencyKey) {
-    const { id } = await createJobStrategies.idempotece({
+    const { id } = await createJobStrategies.idempotence({
       service,
       targetFn,
       targetArgs,

--- a/control-plane/src/modules/jobs.ts
+++ b/control-plane/src/modules/jobs.ts
@@ -2,33 +2,102 @@ import { and, eq, sql } from "drizzle-orm";
 import { ulid } from "ulid";
 import * as cron from "./cron";
 import * as data from "./data";
-import { backgrounded } from "./util";
 import { writeEvent, writeJobActivity } from "./events";
 import {
   ServiceDefinition,
+  getServiceDefinitions,
   storeServiceDefinitionBG,
 } from "./service-definitions";
+import { backgrounded } from "./util";
 
-export const createJob = async ({
-  service,
-  targetFn,
-  targetArgs,
-  owner,
-  pool,
-  idempotencyKey,
-}: {
-  service: string;
-  targetFn: string;
-  targetArgs: string;
-  owner: { clusterId: string };
-  pool?: string;
-  idempotencyKey?: string;
-}) => {
-  const jobId = idempotencyKey ?? ulid();
+const createJobStrategies = {
+  idempotece: async ({
+    service,
+    targetFn,
+    targetArgs,
+    owner,
+    pool,
+    idempotencyKey,
+  }: {
+    service: string;
+    targetFn: string;
+    targetArgs: string;
+    owner: { clusterId: string };
+    pool?: string;
+    idempotencyKey: string;
+  }) => {
+    const jobId = idempotencyKey;
 
-  await data.db
-    .insert(data.jobs)
-    .values({
+    await data.db
+      .insert(data.jobs)
+      .values({
+        id: idempotencyKey,
+        target_fn: targetFn,
+        target_args: targetArgs,
+        idempotency_key: jobId,
+        status: "pending",
+        owner_hash: owner.clusterId,
+        machine_type: pool,
+        service,
+      })
+      .onConflictDoNothing();
+
+    return { id: jobId };
+  },
+  cached: async ({
+    service,
+    targetFn,
+    targetArgs,
+    owner,
+    pool,
+    cacheKey,
+  }: {
+    service: string;
+    targetFn: string;
+    targetArgs: string;
+    owner: { clusterId: string };
+    pool?: string;
+    cacheKey: string;
+  }) => {
+    const cacheTTL = await getServiceDefinitions(owner)
+      .then(
+        (defs) =>
+          defs
+            ?.find((def) => def.name === service)
+            ?.functions?.find((fn) => fn.name === targetFn)?.cacheTTL,
+      )
+      .catch(() => undefined); // on error, just don't cache
+
+    // has a job been completed within the TTL?
+    // if so, return the jobId
+
+    const [job] = await data.db
+      .select({
+        id: data.jobs.id,
+      })
+      .from(data.jobs)
+      .where(
+        and(
+          eq(data.jobs.cache_key, cacheKey),
+          eq(data.jobs.owner_hash, owner.clusterId),
+          eq(data.jobs.service, service),
+          eq(data.jobs.target_fn, targetFn),
+          eq(data.jobs.status, "success"),
+          eq(data.jobs.result_type, "resolution"),
+          sql`resulted_at > now() - interval '${cacheTTL} ms'`,
+        ),
+      )
+      .orderBy(data.jobs.resulted_at, sql`DESC`)
+      .limit(1);
+
+    if (job) {
+      return { id: job.id };
+    }
+
+    // if not, create a job
+    const jobId = ulid();
+
+    await data.db.insert(data.jobs).values({
       id: jobId,
       target_fn: targetFn,
       target_args: targetArgs,
@@ -37,9 +106,60 @@ export const createJob = async ({
       owner_hash: owner.clusterId,
       machine_type: pool,
       service,
-    })
-    .onConflictDoNothing();
+      cache_key: cacheKey,
+    });
 
+    return { id: jobId };
+  },
+  default: async ({
+    service,
+    targetFn,
+    targetArgs,
+    owner,
+    pool,
+  }: {
+    service: string;
+    targetFn: string;
+    targetArgs: string;
+    owner: { clusterId: string };
+    pool?: string;
+  }) => {
+    const jobId = ulid();
+
+    await data.db.insert(data.jobs).values({
+      id: jobId,
+      target_fn: targetFn,
+      target_args: targetArgs,
+      idempotency_key: jobId,
+      status: "pending",
+      owner_hash: owner.clusterId,
+      machine_type: pool,
+      service,
+    });
+
+    return { id: jobId };
+  },
+};
+
+const onAfterJobCreated = async ({
+  service,
+  targetFn,
+  targetArgs,
+  owner,
+  pool,
+  idempotencyKey,
+  cacheKey,
+  jobId,
+}: {
+  service: string;
+  targetFn: string;
+  targetArgs: string;
+  owner: { clusterId: string };
+  pool?: string;
+  idempotencyKey?: string;
+  cacheKey?: string;
+  jobId: string;
+}) => {
   writeEvent({
     type: "jobCreated",
     tags: {
@@ -62,8 +182,88 @@ export const createJob = async ({
       targetArgs,
     },
   });
+};
 
-  return { id: jobId };
+export const createJob = async ({
+  service,
+  targetFn,
+  targetArgs,
+  owner,
+  pool,
+  idempotencyKey,
+  cacheKey,
+}: {
+  service: string;
+  targetFn: string;
+  targetArgs: string;
+  owner: { clusterId: string };
+  pool?: string;
+  idempotencyKey?: string;
+  cacheKey?: string;
+}) => {
+  // TODO: refactor this
+  if (idempotencyKey) {
+    const { id } = await createJobStrategies.idempotece({
+      service,
+      targetFn,
+      targetArgs,
+      owner,
+      pool,
+      idempotencyKey,
+    });
+
+    onAfterJobCreated({
+      service,
+      targetFn,
+      targetArgs,
+      owner,
+      pool,
+      idempotencyKey,
+      jobId: id,
+    });
+
+    return { id };
+  } else if (cacheKey) {
+    const { id } = await createJobStrategies.cached({
+      service,
+      targetFn,
+      targetArgs,
+      owner,
+      pool,
+      cacheKey,
+    });
+
+    onAfterJobCreated({
+      service,
+      targetFn,
+      targetArgs,
+      owner,
+      pool,
+      cacheKey,
+      jobId: id,
+    });
+
+    return { id };
+  } else {
+    const { id } = await createJobStrategies.default({
+      service,
+      targetFn,
+      targetArgs,
+      owner,
+      pool,
+    });
+
+    onAfterJobCreated({
+      service,
+      targetFn,
+      targetArgs,
+      owner,
+      pool,
+      jobId: id,
+    });
+
+    return { id };
+  }
 };
 
 export const nextJobs = async ({

--- a/control-plane/src/modules/service-definitions.ts
+++ b/control-plane/src/modules/service-definitions.ts
@@ -1,7 +1,13 @@
 import { and, eq } from "drizzle-orm";
+import NodeCache from "node-cache";
+import { z } from "zod";
 import * as data from "./data";
 import { backgrounded } from "./util";
-import { z } from "zod";
+
+const cache = new NodeCache({
+  stdTTL: 5,
+  maxKeys: 10000,
+});
 
 export type ServiceDefinition = {
   name: string;
@@ -31,17 +37,17 @@ export const serviceDefinitionsSchema = z.array(
             })
             .optional(),
           cacheTTL: z.number().optional(),
-        })
+        }),
       )
       .optional(),
-  })
+  }),
 );
 
 export const storeServiceDefinitionBG = backgrounded(
   async function storeServiceDefinition(
     service: string,
     definition: ServiceDefinition,
-    owner: { clusterId: string }
+    owner: { clusterId: string },
   ) {
     await data.db
       .insert(data.services)
@@ -56,10 +62,14 @@ export const storeServiceDefinitionBG = backgrounded(
           definition,
         },
       });
-  }
+  },
 );
 
 export async function getServiceDefinitions(owner: { clusterId: string }) {
+  if (cache.has(owner.clusterId)) {
+    return cache.get<ServiceDefinition[]>(owner.clusterId);
+  }
+
   const serviceDefinitions = await data.db
     .select({
       definition: data.services.definition,
@@ -67,7 +77,13 @@ export async function getServiceDefinitions(owner: { clusterId: string }) {
     .from(data.services)
     .where(and(eq(data.services.cluster_id, owner.clusterId)));
 
-  return serviceDefinitionsSchema.parse([serviceDefinitions[0]?.definition]);
+  const retrieved = serviceDefinitionsSchema.parse([
+    serviceDefinitions[0]?.definition,
+  ]);
+
+  cache.set(owner.clusterId, retrieved);
+
+  return retrieved;
 }
 
 export const parseServiceDefinition = (input: unknown): ServiceDefinition[] => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0",
         "msgpackr": "^1.10.1",
+        "node-cache": "^5.1.2",
         "nodemon": "^3.0.1",
         "pg": "^8.11.2",
         "ts-node": "^10.9.1",
@@ -14385,6 +14386,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-cache/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/node-fetch": {


### PR DESCRIPTION
Add caching to differential functions.

```ts
// src/services/product.ts

const getProduct = async (productId: string) => {
  const product = await getProductFromDatabase(productId);
  return product;
};

export const productService = d.service({
  name: "product",
  functions: {
    getProduct: cached(getProduct, 10000), // cache results for 10 seconds
  },
});

// src/client.ts

const productClient = d.client<typeof productService>("product");

const productId = "123";

const product = await productClient.getProduct(productId, {
  $cacheKey: productId,
});

// if you call the function again with the same cache key, previous result will be returned

const product2 = await productClient.getProduct(productId, {
  $cacheKey: productId,
});

assert.deepEqual(product === product2);
```