### PR TITLE
fix: Fix serializing unregistered function errors

### DIFF
--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -9,12 +9,11 @@ import {
   retryConfigForFunction,
 } from "./functions";
 import { pack, unpack } from "./serialize";
+import { deserializeError, serializeError } from "./serialize-error";
 import { Result, TaskQueue } from "./task-queue";
 import { AsyncFunction } from "./types";
 
 const log = debug("differential:client");
-
-const { serializeError, deserializeError } = require("./errors");
 
 type ServiceClient<T extends RegisteredService<any>> = {
   [K in keyof T["definition"]["functions"]]: T["definition"]["functions"][K];
@@ -277,11 +276,7 @@ class PollingAgent {
 
           if (!registered) {
             const error = new DifferentialError(
-              `Function was not registered. name='${
-                job.targetFn
-              }' registeredFunctions='${Object.keys(functionRegistry).join(
-                ",",
-              )}'`,
+              `Function was not registered. name='${job.targetFn}'`,
             );
 
             await onComplete({

--- a/ts-core/src/task-queue.test.ts
+++ b/ts-core/src/task-queue.test.ts
@@ -138,3 +138,20 @@ describe("TaskQueue", () => {
     await taskQueue.quit();
   });
 });
+
+describe("executeFn", () => {
+  it("should resolve the result of the function", async () => {
+    const fn = () => Promise.resolve("result");
+    const result = await fn();
+    expect(result).toBe("result");
+  });
+
+  it("should resolve the result of the function", async () => {
+    const fn = () => Promise.reject("error");
+    try {
+      await fn();
+    } catch (err) {
+      expect(err).toBe("error");
+    }
+  });
+});

--- a/ts-core/src/task-queue.ts
+++ b/ts-core/src/task-queue.ts
@@ -10,9 +10,9 @@ export type Result<T = unknown> = {
   functionExecutionTime?: number;
 };
 
-const executeFn = async (
+export const executeFn = async (
   fn: AsyncFunction,
-  args: Parameters<AsyncFunction>
+  args: Parameters<AsyncFunction>,
 ): Promise<Result> => {
   const start = Date.now();
   try {
@@ -40,7 +40,7 @@ const executeFn = async (
     } else {
       return {
         content: new Error(
-          "Differential encountered an unexpected error type. Make sure you are throwing an Error object."
+          "Differential encountered an unexpected error type. Make sure you are throwing an Error object.",
         ),
         type: "rejection",
         functionExecutionTime,
@@ -61,7 +61,7 @@ export class TaskQueue {
   addTask(
     fn: AsyncFunction,
     args: Parameters<AsyncFunction>,
-    resolve: (value: Result) => void
+    resolve: (value: Result) => void,
   ) {
     this.tasks.push({
       fn,
@@ -79,7 +79,7 @@ export class TaskQueue {
     this.tasks = [];
 
     Promise.all(
-      tasks.map((task) => executeFn(task.fn, task.args).then(task.resolve))
+      tasks.map((task) => executeFn(task.fn, task.args).then(task.resolve)),
     ).then(() => {
       this.isRunning = false;
     });


### PR DESCRIPTION
Due to a weakly-typed import, unregistered function errors are not serialised properly. This PR fixes it and types the import strongly.