### PR TITLE
feat: Add management token for self hosting

### DIFF
--- a/control-plane/src/modules/jwt.test.ts
+++ b/control-plane/src/modules/jwt.test.ts
@@ -19,7 +19,33 @@ describe("verifyManagementToken", () => {
     const token = `1234`;
 
     await expect(
-      jwt.verifyManagementToken({ managementToken: token })
+      jwt.verifyManagementToken({ managementToken: token }),
     ).rejects.toThrowError("jwt malformed");
+  });
+
+  it("should accept a correct management secret", async () => {
+    const token =
+      "sk_management_98a7oysidtghfkjbaslnd;fuays87otdiygfukahjsbdlf;a;soihudyfgajvshkbdlnf;asdfh";
+
+    process.env.MANAGEMENT_SECRET = token;
+
+    const result = await jwt.verifyManagementToken({
+      managementToken: token,
+    });
+
+    expect(result).toEqual({
+      userId: "control-plane-administrator",
+    });
+  });
+
+  it("should throw on an incorrect management secret", async () => {
+    const token =
+      "sk_management_98a7oysidtghfkjbaslnd;fuays87otdiygfukahjsbdlf;a;soihudyfgajvshkbdlnf;asdfh";
+
+    process.env.MANAGEMENT_SECRET = token;
+
+    await expect(
+      jwt.verifyManagementToken({ managementToken: "sk_management_1234" }),
+    ).rejects.toThrowError("Invalid token");
   });
 });

--- a/control-plane/src/modules/jwt.ts
+++ b/control-plane/src/modules/jwt.ts
@@ -32,7 +32,15 @@ const client = process.env.JWKS_URL
   : null;
 
 const getKey: GetPublicKeyOrSecret = (header, callback) => {
-  return client?.getSigningKey(header.kid, function (err, key) {
+  if (!client) {
+    return callback(
+      new Error(
+        "JWKS client not initialized. Probably missing JWKS_URL in env.",
+      ),
+    );
+  }
+
+  return client.getSigningKey(header.kid, function (err, key) {
     var signingKey = key?.getPublicKey();
     callback(err, signingKey);
   });

--- a/control-plane/src/modules/jwt.ts
+++ b/control-plane/src/modules/jwt.ts
@@ -8,16 +8,31 @@ export class AuthenticationError extends Error {
   }
 }
 
-if (!process.env.JWKS_URL) {
-  throw new Error("JWKS_URL must be set");
+if (!process.env.JWKS_URL && !process.env.MANAGEMENT_SECRET) {
+  throw new Error("No JWKS_URL or MANAGEMENT_SECRET in env. One is required.");
 }
 
-const client = jwksClient({
-  jwksUri: process.env.JWKS_URL,
-});
+if (process.env.MANAGEMENT_SECRET) {
+  const hasPrefix = process.env.MANAGEMENT_SECRET.startsWith("sk_management_");
+  const hasLength = process.env.MANAGEMENT_SECRET.length > 64;
+
+  if (!hasPrefix) {
+    throw new Error("MANAGEMENT_SECRET must start with sk_management_");
+  }
+
+  if (!hasLength) {
+    throw new Error("MANAGEMENT_SECRET must be longer than 64 characters");
+  }
+}
+
+const client = process.env.JWKS_URL
+  ? jwksClient({
+      jwksUri: process.env.JWKS_URL,
+    })
+  : null;
 
 const getKey: GetPublicKeyOrSecret = (header, callback) => {
-  return client.getSigningKey(header.kid, function (err, key) {
+  return client?.getSigningKey(header.kid, function (err, key) {
     var signingKey = key?.getPublicKey();
     callback(err, signingKey);
   });
@@ -30,6 +45,20 @@ export const verifyManagementToken = async ({
 }): Promise<{
   userId: string;
 }> => {
+  const managementSecretAuthEnabled = Boolean(process.env.MANAGEMENT_SECRET);
+
+  if (managementSecretAuthEnabled && managementToken) {
+    const secretsMatch = managementToken === process.env.MANAGEMENT_SECRET;
+
+    if (secretsMatch) {
+      return {
+        userId: "control-plane-administrator",
+      };
+    } else {
+      throw new AuthenticationError("Invalid token");
+    }
+  }
+
   return new Promise((resolve, reject) => {
     jwt.verify(
       managementToken,
@@ -54,7 +83,7 @@ export const verifyManagementToken = async ({
         return resolve({
           userId: decoded.sub,
         });
-      }
+      },
     );
   });
 };

--- a/control-plane/src/modules/jwt.ts
+++ b/control-plane/src/modules/jwt.ts
@@ -38,6 +38,8 @@ const getKey: GetPublicKeyOrSecret = (header, callback) => {
   });
 };
 
+export const CONTROL_PLANE_ADMINISTRATOR = "control-plane-administrator";
+
 export const verifyManagementToken = async ({
   managementToken,
 }: {
@@ -52,7 +54,7 @@ export const verifyManagementToken = async ({
 
     if (secretsMatch) {
       return {
-        userId: "control-plane-administrator",
+        userId: CONTROL_PLANE_ADMINISTRATOR,
       };
     } else {
       throw new AuthenticationError("Invalid token");

--- a/control-plane/src/modules/management.ts
+++ b/control-plane/src/modules/management.ts
@@ -63,6 +63,10 @@ export const hasAccessToCluster = async ({
 }): Promise<boolean> => {
   const verified = await jwt.verifyManagementToken({ managementToken });
 
+  if (verified.userId === jwt.CONTROL_PLANE_ADMINISTRATOR) {
+    return true;
+  }
+
   const clusters = await data.db
     .select({
       id: data.clusters.id,


### PR DESCRIPTION
Introduces the ability to configure a `MANAGEMENT_SECRET` in the control plane for basic secret authentication, so self-hosting deployments can bypass Clerk.