### PR TITLE
docs: Adding self-hosting guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All documentation is hosted at [docs.differential.dev](https://docs.differential
 - [Quick Start](https://docs.differential.dev/getting-started/quick-start/)
 - [Thinking in Differential](https://docs.differential.dev/getting-started/thinking/)
 - [How it works under the hood](https://docs.differential.dev/advanced/architecture/)
-- Self-hosting (Coming soon)
+- [Self-hosting](https://docs.differential.dev/advanced/self-hosting/)
 
 # Features
 
@@ -68,6 +68,7 @@ All documentation is hosted at [docs.differential.dev](https://docs.differential
 - [x] [Observability and tracing at the function level](https://forms.fillout.com/t/9M1VhL8Wxyus)
 - [x] [Service registry](https://forms.fillout.com/t/9M1VhL8Wxyus)
 - [x] [Cache function results globally](https://docs.differential.dev/advanced/advanced-usage/#global-cache)
+- [x] [Self-hosting on your own infrastructure](https://docs.differential.dev/advanced/self-hosting/)
 - [ ] Per-function rate limiting
 - [ ] One-line deployment to AWS Lambda
 - [ ] AI-generated developer documentation

--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This repo contains the source code for the Differential control plane. Control plane acts as an application code aware service mesh, and a distributed orchestrator. It implements a few things on top of Postgres and InfluxDB:
+This repo contains the source code for the Differential control plane. Control plane acts as an application code aware service mesh, and a distributed orchestrator. It implements a few things on top of Postgres:
 
 - Queue with exactly-once processing semantics
 - Service & function registry
@@ -16,55 +16,7 @@ See the [Documentation](https://docs.differential.dev) for more information.
 
 ## How do I self-host?
 
-### Using Docker
-
-The easiest way to self-host is to use our Docker image defined in this repo. To do so:
-
-1. Clone this repo and build the docker image:
-
-```sh
-docker build -t differential .
-```
-
-2. Set the following environment variables:
-
-```sh
-DATABASE_URL=postgres://user:password@host:port/database
-```
-
-3. Run the docker image.
-
-```sh
-docker run -p 3000:3000 differential
-```
-
-### Using fly.io
-
-This repo contains a [fly.toml](./fly.toml) file that allows you to deploy Differential to [fly.io](https://fly.io) using the Docker image defined in this repo. To do so:
-
-1. Authenticate with fly.io:
-
-```sh
-flyctl auth login
-```
-
-2. Create a fly.io app:
-
-```sh
-flyctl apps create
-```
-
-3. Set the following environment variables:
-
-```sh
-flyctl secrets set DATABASE_URL=postgres://user:password@host:port/database
-```
-
-4. Deploy to fly.io:
-
-```sh
-flyctl deploy
-```
+You can self-host the Differential control-plane using your own compute, as long as you can run a Docker container. Differential only requires a postgres database for persistence. See the detailed guide to self-hosting using fly.io [here](https://docs.differential.dev/advanced/self-hosting).
 
 ## Contributing
 

--- a/control-plane/fly.toml
+++ b/control-plane/fly.toml
@@ -1,8 +1,3 @@
-# fly.toml app configuration file generated for differential-core on 2023-08-23T22:01:07+10:00
-#
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
-#
-
 app = "differential-core"
 primary_region = "lax"
 

--- a/docs/advanced/self-hosting.md
+++ b/docs/advanced/self-hosting.md
@@ -1,0 +1,86 @@
+# Self-hosting
+
+You can self-host the Differential control-plane using your own compute, as long as you can run a Docker container. Differential only requires a postgres database for persistence.
+
+## Guide to self-hosting using fly.io
+
+### Creating the fly app
+
+1. Clone the repo:
+
+```sh
+git clone git@github.com:differentialhq/differential.git && cd differential/control-plane
+```
+
+2. Create a fly app, and note the app name:
+
+```sh
+fly apps create
+```
+
+3. Open the fly.toml file and replace `"differential-core"` with the app name you noted in the previous step.
+
+4. Deploy to fly.io:
+
+```sh
+fly deploy --vm-cpu-kind "shared" --vm-cpus "1" --vm-memory "512"
+```
+
+5. You will need to set a secret to access to the management functions of the control-plane. We will save the secret to a `management-secret.txt` file for now. You can do this by running:
+
+```sh
+# MANAGEMENT_SECRET must start with "sk_management_" and contain at least 32 characters
+MANAGEMENT_SECRET="sk_management_$(openssl rand -base64 32)"
+echo "$MANAGEMENT_SECRET" > management-secret.txt
+fly secrets set MANAGEMENT_SECRET="sk_management_$(openssl rand -base64 32)"
+```
+
+### Creating the postgres instance
+
+1. Next, you will need to provision a postgres instance. You can use any postgres provider, but for this purpose, we will use fly postgres. Note the fly postgres app name when you create it.
+
+```sh
+fly postgres create
+```
+
+2. Attach the postgres instance to the fly app. This will set the DATABASE_URL environment variable in the fly app.
+
+```sh
+fly postgres attach <postgres app name from step 6>
+```
+
+### Creating your first cluster
+
+1. Assuming the app is created and the postgres instance is attached, you can now create your first cluster. Assuming your app is exposed at `differential-core.fly.dev`, you can create a cluster by running:
+
+```sh
+curl -X POST -H "Authorization: Basic $(cat management-secret.txt)" -H "Content-Type: application/json" https://differential-core.fly.dev/clusters
+```
+
+2. Now, you can retrieve the cluster information by running:
+
+```sh
+curl -H "Authorization: Basic $(cat management-secret.txt)" https://differential-core.fly.dev/clusters
+```
+
+You will only need the `apiSecret` from the response.
+
+### Connecting to the control-plane
+
+To connect to the cluster, you need:
+
+1. The Typescript SDK
+2. The endpoint where the control-plane is hosted
+3. The `apiSecret` from the previous step
+
+When initializing the SDK, you will need to pass the `apiSecret` and the `endpoint` to the `Differential` class.
+
+```ts
+import { Differential } from "@differentialhq/core";
+
+const differential = new Differential("MY_API_SECRET", {
+  endpoint: "https://MY_CONTROL_PLANE_APP.fly.dev",
+});
+```
+
+And that's it!


### PR DESCRIPTION
Adding a more comprehensive self-hosting guide and detailed steps to use fly compute and fly postgres.