### PR TITLE
feat(cli): Release deployments

### DIFF
--- a/cli/src/client/contract.ts
+++ b/cli/src/client/contract.ts
@@ -384,14 +384,52 @@ export const definition = {
     headers: z.object({
       authorization: z.string(),
     }),
-    body: z.object({}),
+    body: z.undefined(),
     responses: {
       501: z.undefined(),
-      403: z.undefined(),
+      401: z.undefined(),
       200: z.object({
         id: z.string(),
         packageUploadUrl: z.string(),
         definitionUploadUrl: z.string(),
+        status: z.string(),
+      }),
+    },
+  },
+  getDeployment: {
+    method: "GET",
+    path: "/clusters/:clusterId/service/:serviceName/deployments/:deploymentId",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    body: z.undefined(),
+    responses: {
+      401: z.undefined(),
+      404: z.undefined(),
+      200: z.object({
+        id: z.string(),
+        packageUploadUrl: z.string(),
+        definitionUploadUrl: z.string(),
+        status: z.string(),
+      }),
+    },
+  },
+  releaseDeployment: {
+    method: "POST",
+    path: "/clusters/:clusterId/service/:serviceName/deployments/:deploymentId/release",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    body: z.undefined(),
+    responses: {
+      400: z.undefined(),
+      401: z.undefined(),
+      404: z.undefined(),
+      200: z.object({
+        id: z.string(),
+        packageUploadUrl: z.string(),
+        definitionUploadUrl: z.string(),
+        status: z.string(),
       }),
     },
   },

--- a/cli/src/lib/client.ts
+++ b/cli/src/lib/client.ts
@@ -1,0 +1,42 @@
+import { initClient, tsRestFetchApi } from "@ts-rest/core";
+import { contract } from "../client/contract";
+
+export const client = initClient(contract, {
+  baseUrl: process.env.DIFFERENTIAL_API_URL || "https://api.differential.dev",
+  baseHeaders: {
+    authorization: `Bearer ${process.env.DIFFERENTIAL_API_TOKEN}`,
+  },
+  api: tsRestFetchApi,
+});
+
+export const waitForDeploymentStatus = async (
+  deploymentId: string,
+  serviceName: string,
+  clusterId: string,
+  target: string,
+  maxAttempts: number = 10,
+) => {
+  const checkDeployment = () =>
+    client.getDeployment({
+      params: {
+        deploymentId,
+        clusterId,
+        serviceName,
+      },
+    });
+
+  let attempts = 0;
+  while (attempts < maxAttempts) {
+    attempts++;
+    const result = await checkDeployment();
+
+    if (result.status == 200 && result.body.status === target) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(
+    "Failed to check deployment status. Please check provided options and cluster configuration.",
+  );
+};

--- a/cli/src/lib/release.ts
+++ b/cli/src/lib/release.ts
@@ -1,0 +1,24 @@
+import { client } from "./client";
+
+export const release = async ({
+  deploymentId,
+  clusterId,
+  serviceName,
+}: {
+  deploymentId: string;
+  clusterId: string;
+  serviceName: string;
+}) => {
+  const result = await client.releaseDeployment({
+    params: {
+      deploymentId,
+      clusterId,
+      serviceName,
+    },
+  });
+  if (result.status !== 200) {
+    throw new Error(
+      "Failed to deploy service. Please check provided options and cluster configuration.",
+    );
+  }
+};

--- a/control-plane/src/modules/deployment/deployment.ts
+++ b/control-plane/src/modules/deployment/deployment.ts
@@ -116,8 +116,8 @@ export const releaseDeployment = async (
 ): Promise<Deployment> => {
   // Check if the service has been previously "released" (active or inactive) deployment
   let meta = (await previouslyReleased(deployment))
-    ? provider.update(deployment)
-    : provider.create(deployment);
+    ? await provider.update(deployment)
+    : await provider.create(deployment);
 
   // This should happen outside of the request
   // as we should be waiting / checking that the resource has been published before we update the deployment status

--- a/control-plane/src/modules/deployment/deployment.ts
+++ b/control-plane/src/modules/deployment/deployment.ts
@@ -115,7 +115,7 @@ export const releaseDeployment = async (
   provider: DeploymentProvider = mockProvider,
 ): Promise<Deployment> => {
   // Check if the service has been previously "released" (active or inactive) deployment
-  let meta = (await previouslyReleased(deployment))
+  const meta = (await previouslyReleased(deployment))
     ? await provider.update(deployment)
     : await provider.create(deployment);
 


### PR DESCRIPTION
The `differential deploy` command will now call the `/release` endpoint after uploading a service assets.

Adds polling for deployment status,  this is currently a noop as the deployment state is moved as part of the `/release` call however that will be moved into a background process in the future.

<img width="584" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/a1f3ee9f-b216-4f0c-b92e-9bfb120f57fb">

