### PR TITLE
feat: Initial deployment scheduling

### DIFF
--- a/control-plane/drizzle/0036_ambiguous_human_robot.sql
+++ b/control-plane/drizzle/0036_ambiguous_human_robot.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "deployment_notifications" (
+	"id" varchar(1024) PRIMARY KEY NOT NULL,
+	"deployment_id" varchar(1024) NOT NULL,
+	"created_at" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "deployment_id" varchar(1024);--> statement-breakpoint
+ALTER TABLE "machines" ADD COLUMN "deployment_id" varchar;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "deployment_notifications" ADD CONSTRAINT "deployment_notifications_deployment_id_deployments_id_fk" FOREIGN KEY ("deployment_id") REFERENCES "deployments"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/control-plane/drizzle/meta/0036_snapshot.json
+++ b/control-plane/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,589 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "cbf6ebb9-da4c-4e9f-bd89-731e5e76e0d6",
+  "prevId": "4c412010-dcf7-4de6-a1d0-0ea91f5b03a1",
+  "tables": {
+    "clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_secret": {
+          "name": "api_secret",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "wake_up_config": {
+          "name": "wake_up_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_enabled": {
+          "name": "cloud_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "predictive_retries_enabled": {
+          "name": "predictive_retries_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployment_notifications": {
+      "name": "deployment_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_notifications_deployment_id_deployments_id_fk": {
+          "name": "deployment_notifications_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_notifications",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployment_provider_config": {
+      "name": "deployment_provider_config",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "package_upload_path": {
+          "name": "package_upload_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_upload_url": {
+          "name": "definition_upload_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployments_cluster_id_clusters_id_fk": {
+          "name": "deployments_cluster_id_clusters_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_cluster_id_clusters_id_fk": {
+          "name": "events_cluster_id_clusters_id_fk",
+          "tableFrom": "events",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_job_id_jobs_id_fk": {
+          "name": "events_job_id_jobs_id_fk",
+          "tableFrom": "events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_machine_id_machines_id_fk": {
+          "name": "events_machine_id_machines_id_fk",
+          "tableFrom": "events",
+          "tableTo": "machines",
+          "columnsFrom": [
+            "machine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_hash": {
+          "name": "owner_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_args": {
+          "name": "target_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_type": {
+          "name": "machine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_attempts": {
+          "name": "remaining_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resulted_at": {
+          "name": "resulted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "function_execution_time_ms": {
+          "name": "function_execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_interval_seconds": {
+          "name": "timeout_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "predicted_to_be_retryable": {
+          "name": "predicted_to_be_retryable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicted_to_be_retryable_reason": {
+          "name": "predicted_to_be_retryable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jobs_owner_hash_target_fn_idempotency_key": {
+          "name": "jobs_owner_hash_target_fn_idempotency_key",
+          "columns": [
+            "owner_hash",
+            "target_fn",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "jobs_id_unique": {
+          "name": "jobs_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_provider": {
+          "name": "deployment_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_cluster_id_clusters_id_fk": {
+          "name": "services_cluster_id_clusters_id_fk",
+          "tableFrom": "services",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "services_cluster_id_service": {
+          "name": "services_cluster_id_service",
+          "columns": [
+            "cluster_id",
+            "service"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/control-plane/drizzle/meta/_journal.json
+++ b/control-plane/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1707426924338,
       "tag": "0035_eminent_fantastic_four",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "5",
+      "when": 1707540255341,
+      "tag": "0036_ambiguous_human_robot",
+      "breakpoints": true
     }
   ]
 }

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -8,6 +8,7 @@ import process from "process";
 import * as jobs from "./modules/jobs/jobs";
 import * as events from "./modules/observability/events";
 import * as router from "./modules/router";
+import * as deploymentScheduler from "./modules/deployment/scheduler";
 
 const app = fastify({
   logger: process.env.ENABLE_FASTIFY_LOGGER === "true",
@@ -30,6 +31,7 @@ app.setErrorHandler((error, request, reply) => {
 const start = async () => {
   await jobs.start();
   await events.initialize();
+  await deploymentScheduler.start();
 
   try {
     await app.listen({ port: 4000, host: "0.0.0.0" });

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -58,6 +58,7 @@ export const jobs = pgTable(
     // TODO: (good-first-issue) rename this column to execution_id
     id: varchar("id", { length: 1024 }).notNull().unique(),
     owner_hash: text("owner_hash").notNull(),
+    deployment_id: varchar("deployment_id", { length: 1024 }),
     target_fn: varchar("target_fn", { length: 1024 }).notNull(),
     target_args: text("target_args").notNull(),
     idempotency_key: varchar("idempotency_key", { length: 1024 }).notNull(),
@@ -97,6 +98,7 @@ export const machines = pgTable("machines", {
   last_ping_at: timestamp("last_ping_at", { withTimezone: true }),
   ip: varchar("ip", { length: 1024 }),
   cluster_id: varchar("cluster_id").notNull(),
+  deployment_id: varchar("deployment_id"),
 });
 
 export const clusters = pgTable("clusters", {
@@ -178,6 +180,19 @@ export const deployments = pgTable("deployments", {
   provider: text("provider", {
     enum: ["lambda", "mock"],
   }).notNull(),
+});
+
+export const deploymentNotification = pgTable("deployment_notifications", {
+  id: varchar("id", { length: 1024 }).primaryKey().notNull(),
+  deployment_id: varchar("deployment_id", { length: 1024 })
+    .references(() => deployments.id)
+    .notNull(),
+  created_at: timestamp("created_at", {
+    withTimezone: true,
+    precision: 6,
+  })
+    .defaultNow()
+    .notNull(),
 });
 
 export const deploymentProvividerConfig = pgTable(

--- a/control-plane/src/modules/deployment/deployment-provider.ts
+++ b/control-plane/src/modules/deployment/deployment-provider.ts
@@ -43,5 +43,11 @@ export interface DeploymentProvider {
   // Update an existing deployment
   update: (deployment: Deployment) => Promise<any>;
   // Notify the provider of a a new job
-  notify: (deployment: Deployment) => Promise<any>;
+  notify: (
+    deployment: Deployment,
+    pendingJobs: number,
+    runningMachines: number,
+  ) => Promise<any>;
+  // How frequently the provider should be notified of new jobs
+  minimumNotificationInterval: () => number;
 }

--- a/control-plane/src/modules/deployment/deployment.test.ts
+++ b/control-plane/src/modules/deployment/deployment.test.ts
@@ -77,11 +77,7 @@ describe("getDeployment", () => {
       serviceName: "testService",
     });
 
-    const result = await getDeployment({
-      clusterId: owner.clusterId,
-      serviceName: "testService",
-      id,
-    });
+    const result = await getDeployment(id);
 
     expect(result.id).toEqual(id);
     expect(result.clusterId).toEqual(owner.clusterId);
@@ -99,6 +95,7 @@ describe("releaseDeployment", () => {
     create: jest.fn(),
     update: jest.fn(),
     notify: jest.fn(),
+    minimumNotificationInterval: jest.fn(),
   };
 
   beforeAll(async () => {
@@ -150,13 +147,7 @@ describe("releaseDeployment", () => {
 
     await releaseDeployment(deployment, provider);
 
-    expect(
-      await getDeployment({
-        clusterId: owner.clusterId,
-        serviceName: "testService",
-        id: deployment.id,
-      }),
-    ).toEqual({
+    expect(await getDeployment(deployment.id)).toEqual({
       ...deployment,
       status: "active",
     });
@@ -169,23 +160,11 @@ describe("releaseDeployment", () => {
     await releaseDeployment(deployment2, provider);
 
     // Deployment 2 is now active and deployment 1 is inactive
-    expect(
-      await getDeployment({
-        clusterId: owner.clusterId,
-        serviceName: "testService",
-        id: deployment.id,
-      }),
-    ).toEqual({
+    expect(await getDeployment(deployment.id)).toEqual({
       ...deployment,
       status: "inactive",
     });
-    expect(
-      await getDeployment({
-        clusterId: owner.clusterId,
-        serviceName: "testService",
-        id: deployment2.id,
-      }),
-    ).toEqual({
+    expect(await getDeployment(deployment2.id)).toEqual({
       ...deployment2,
       status: "active",
     });

--- a/control-plane/src/modules/deployment/mock-deployment-provider.ts
+++ b/control-plane/src/modules/deployment/mock-deployment-provider.ts
@@ -11,6 +11,10 @@ export class MockProvider implements DeploymentProvider {
     return z.object({});
   }
 
+  public minimumNotificationInterval(): number {
+    return 10000;
+  }
+
   public async create(deployment: Deployment): Promise<any> {
     console.log("Would create new deployment", deployment);
   }
@@ -19,7 +23,15 @@ export class MockProvider implements DeploymentProvider {
     console.log("Would update existing deployment", deployment);
   }
 
-  public async notify(deployment: Deployment): Promise<any> {
-    console.log("Would trigger deployment", deployment);
+  public async notify(
+    deployment: Deployment,
+    pendingJobs: number,
+    runningMachines: number,
+  ): Promise<any> {
+    console.log("Would notify provider of new jobs", {
+      deployment,
+      pendingJobs,
+      runningMachines,
+    });
   }
 }

--- a/control-plane/src/modules/deployment/scheduler.ts
+++ b/control-plane/src/modules/deployment/scheduler.ts
@@ -1,0 +1,100 @@
+import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { registerCron } from "../cron";
+import * as data from "../data";
+import { getDeploymentProvider } from "./deployment-provider";
+import { ulid } from "ulid";
+import { getDeployment } from "./deployment";
+
+const getJobBacklog = async () => {
+  return await data.db
+    .select({
+      deployment_id: data.jobs.deployment_id,
+      pending: sql<number>`count(${data.jobs.id})`,
+    })
+    .from(data.jobs)
+    .where(eq(data.jobs.status, "pending"))
+    .groupBy(data.jobs.deployment_id);
+};
+
+const getLastNotification = async (
+  deploymentId: string,
+): Promise<{ created_at: Date } | null> => {
+  const notificationResult = await data.db
+    .select({
+      created_at: data.deploymentNotification.created_at,
+    })
+    .from(data.deploymentNotification)
+    .where(eq(data.deploymentNotification.deployment_id, deploymentId))
+    .orderBy(desc(data.deploymentNotification.created_at))
+    .limit(1);
+
+  return notificationResult[0];
+};
+
+const getMachineCount = async (
+  deploymentId: string,
+  lastPingAfter: Date,
+): Promise<number> => {
+  const machines = await data.db
+    .select({
+      count: sql<number>`count(${data.machines.id})`,
+    })
+    .from(data.machines)
+    .where(
+      and(
+        eq(data.machines.deployment_id, deploymentId),
+        gt(data.machines.last_ping_at, lastPingAfter),
+      ),
+    );
+
+  return machines[0].count ?? 0;
+};
+
+// Scheduled job which checks for pending jobs and notifies the deployment providers.
+// This is a naive implementation that will lead to duplicate notifications as there is no locking
+export const start = async () => {
+  if (!process.env.DEPLOYMENT_SCHEDULING_ENABLED) {
+    return;
+  }
+  registerCron(
+    async () => {
+      for (const backlog of await getJobBacklog()) {
+        if (backlog.deployment_id == undefined) continue;
+
+        //TODO: This should be combined with the group by query
+        const deployment = await getDeployment(backlog.deployment_id);
+        if (!deployment) {
+          continue;
+        }
+
+        const provider = getDeploymentProvider(deployment.provider);
+        if (!provider) {
+          continue;
+        }
+
+        const lastNotification = await getLastNotification(deployment.id);
+
+        if (lastNotification) {
+          // Check if the last notification was within the minimum interval
+          const notificationInterval =
+            Date.now() - lastNotification?.created_at.getTime();
+          if (notificationInterval < provider.minimumNotificationInterval()) {
+            continue;
+          }
+        }
+
+        const runningMachines = await getMachineCount(
+          deployment.id,
+          new Date(Date.now() - provider.minimumNotificationInterval()),
+        );
+
+        await data.db.insert(data.deploymentNotification).values({
+          id: ulid(),
+          deployment_id: deployment.id,
+        });
+        await provider.notify(deployment, backlog.pending, runningMachines);
+      }
+    },
+    { interval: 500 },
+  );
+};

--- a/control-plane/src/modules/jobs/create-job.ts
+++ b/control-plane/src/modules/jobs/create-job.ts
@@ -9,6 +9,7 @@ type CreateJobParams = {
   targetFn: string;
   targetArgs: string;
   owner: { clusterId: string };
+  deploymentId?: string;
   pool?: string;
   timeoutIntervalSeconds?: number;
   maxAttempts?: number;
@@ -19,6 +20,7 @@ export const createJob = async (params: {
   targetFn: string;
   targetArgs: string;
   owner: { clusterId: string };
+  deploymentId?: string;
   pool?: string;
   idempotencyKey?: string;
   cacheKey?: string;
@@ -87,6 +89,7 @@ const createJobStrategies = {
     targetFn,
     targetArgs,
     owner,
+    deploymentId,
     pool,
     idempotencyKey,
     timeoutIntervalSeconds,
@@ -103,6 +106,7 @@ const createJobStrategies = {
         idempotency_key: jobId,
         status: "pending",
         owner_hash: owner.clusterId,
+        deployment_id: deploymentId,
         machine_type: pool,
         service,
         remaining_attempts: maxAttempts ?? 1,
@@ -117,6 +121,7 @@ const createJobStrategies = {
     targetFn,
     targetArgs,
     owner,
+    deploymentId,
     pool,
     cacheKey,
     timeoutIntervalSeconds,
@@ -162,6 +167,7 @@ const createJobStrategies = {
       idempotency_key: jobId,
       status: "pending",
       owner_hash: owner.clusterId,
+      deployment_id: deploymentId,
       machine_type: pool,
       service,
       cache_key: cacheKey,
@@ -176,6 +182,7 @@ const createJobStrategies = {
     targetFn,
     targetArgs,
     owner,
+    deploymentId,
     pool,
     timeoutIntervalSeconds,
     maxAttempts,
@@ -189,6 +196,7 @@ const createJobStrategies = {
       idempotency_key: jobId,
       status: "pending",
       owner_hash: owner.clusterId,
+      deployment_id: deploymentId,
       machine_type: pool,
       service,
       remaining_attempts: maxAttempts ?? 1,


### PR DESCRIPTION
Adds initial deployment scheduling.

This PR adds a new scheduled job which periodically scans for "pending" jobs, and notifies the `DeploymentProvider` with the number of jobs and the number of running machines.

The `DeploymentProvider` is then responsible for making a determination around starting up new instances if necessary. Currently, this just starts an instance if none are running.

This is a naive approach, we will want to move this scheduling behaviour into a seperate service or at least introduce some locking so that only one instance of the control plane is handling scheduling at once.

There is also no mechanism for scaling down, as this is not necessary for `LambdaProvider` which will timeout on idle.

Please note: `deployment_id` is not currently being set on the `machines` entities. I will create a seperate PR which set's this value if applicable so that we can determine the running instance count for a deployment.
Initially, I was going to fall back to checking CloudWatch metrics (for `LambdaProvider`), however the 1 minute frequency wouldn't be granular enough.