### PR TITLE
feat: Attach deployment to machine and events

### DIFF
--- a/control-plane/drizzle/0037_empty_molecule_man.sql
+++ b/control-plane/drizzle/0037_empty_molecule_man.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "events" ADD COLUMN "deployment_id" varchar(1024);--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "events" ADD CONSTRAINT "events_deployment_id_deployments_id_fk" FOREIGN KEY ("deployment_id") REFERENCES "deployments"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/control-plane/drizzle/meta/0037_snapshot.json
+++ b/control-plane/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,608 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "42490397-37d2-4e9d-bc95-a4317278ee75",
+  "prevId": "cbf6ebb9-da4c-4e9f-bd89-731e5e76e0d6",
+  "tables": {
+    "clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_secret": {
+          "name": "api_secret",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "wake_up_config": {
+          "name": "wake_up_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_enabled": {
+          "name": "cloud_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "predictive_retries_enabled": {
+          "name": "predictive_retries_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployment_notifications": {
+      "name": "deployment_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_notifications_deployment_id_deployments_id_fk": {
+          "name": "deployment_notifications_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_notifications",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployment_provider_config": {
+      "name": "deployment_provider_config",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "package_upload_path": {
+          "name": "package_upload_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_upload_url": {
+          "name": "definition_upload_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployments_cluster_id_clusters_id_fk": {
+          "name": "deployments_cluster_id_clusters_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_cluster_id_clusters_id_fk": {
+          "name": "events_cluster_id_clusters_id_fk",
+          "tableFrom": "events",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_job_id_jobs_id_fk": {
+          "name": "events_job_id_jobs_id_fk",
+          "tableFrom": "events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_machine_id_machines_id_fk": {
+          "name": "events_machine_id_machines_id_fk",
+          "tableFrom": "events",
+          "tableTo": "machines",
+          "columnsFrom": [
+            "machine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_deployment_id_deployments_id_fk": {
+          "name": "events_deployment_id_deployments_id_fk",
+          "tableFrom": "events",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_hash": {
+          "name": "owner_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_args": {
+          "name": "target_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_type": {
+          "name": "machine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_attempts": {
+          "name": "remaining_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resulted_at": {
+          "name": "resulted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "function_execution_time_ms": {
+          "name": "function_execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_interval_seconds": {
+          "name": "timeout_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "predicted_to_be_retryable": {
+          "name": "predicted_to_be_retryable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicted_to_be_retryable_reason": {
+          "name": "predicted_to_be_retryable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jobs_owner_hash_target_fn_idempotency_key": {
+          "name": "jobs_owner_hash_target_fn_idempotency_key",
+          "columns": [
+            "owner_hash",
+            "target_fn",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "jobs_id_unique": {
+          "name": "jobs_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_provider": {
+          "name": "deployment_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_cluster_id_clusters_id_fk": {
+          "name": "services_cluster_id_clusters_id_fk",
+          "tableFrom": "services",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "services_cluster_id_service": {
+          "name": "services_cluster_id_service",
+          "columns": [
+            "cluster_id",
+            "service"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/control-plane/drizzle/meta/_journal.json
+++ b/control-plane/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1707540255341,
       "tag": "0036_ambiguous_human_robot",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "5",
+      "when": 1707617508556,
+      "tag": "0037_empty_molecule_man",
+      "breakpoints": true
     }
   ]
 }

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -97,6 +97,8 @@ export const definition = {
     path: "/jobs/:jobId/result",
     headers: z.object({
       authorization: z.string(),
+      "x-machine-id": z.string(),
+      "x-deployment-id": z.string().optional(),
     }),
     pathParams: z.object({
       jobId: z.string(),

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -16,6 +16,7 @@ export const definition = {
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
+      "x-deployment-id": z.string().optional(),
     }),
     body: z.object({
       limit: z.coerce.number().default(1),
@@ -339,6 +340,7 @@ export const definition = {
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
+      "x-deployment-id": z.string().optional(),
     }),
     responses: {
       204: z.undefined(),

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -145,6 +145,9 @@ export const events = pgTable("events", {
   machine_id: varchar("machine_id", { length: 1024 }).references(
     () => machines.id,
   ),
+  deployment_id: varchar("deployment_id", { length: 1024 }).references(
+    () => deployments.id,
+  ),
   service: varchar("service", { length: 1024 }),
   created_at: timestamp("created_at", {
     withTimezone: true,

--- a/control-plane/src/modules/jobs/jobs.ts
+++ b/control-plane/src/modules/jobs/jobs.ts
@@ -17,6 +17,7 @@ export const nextJobs = async ({
   owner,
   limit,
   machineId,
+  deploymentId,
   ip,
   definition,
 }: {
@@ -24,6 +25,7 @@ export const nextJobs = async ({
   owner: { clusterId: string };
   limit: number;
   machineId: string;
+  deploymentId?: string;
   ip: string;
   definition?: ServiceDefinition;
 }) => {
@@ -113,6 +115,7 @@ const storeMachineInfoBG = backgrounded(async function storeMachineInfo(
   machineId: string,
   ip: string,
   owner: { clusterId: string },
+  deploymentId?: string,
 ) {
   await data.db
     .insert(data.machines)
@@ -121,6 +124,7 @@ const storeMachineInfoBG = backgrounded(async function storeMachineInfo(
       last_ping_at: new Date(),
       ip,
       cluster_id: owner.clusterId,
+      //deployment_id: deploymentId,
     })
     .onConflictDoUpdate({
       target: data.machines.id,

--- a/control-plane/src/modules/jobs/persist-result.ts
+++ b/control-plane/src/modules/jobs/persist-result.ts
@@ -11,6 +11,7 @@ type PersistResultParams = {
   jobId: string;
   owner: { clusterId: string };
   machineId: string;
+  deploymentId?: string;
 };
 
 export async function persistJobResult({
@@ -20,6 +21,7 @@ export async function persistJobResult({
   jobId,
   owner,
   machineId,
+  deploymentId,
 }: PersistResultParams) {
   const shouldPredictRetry =
     resultType === "rejection" &&
@@ -54,6 +56,7 @@ export async function persistJobResult({
     clusterId: owner.clusterId,
     jobId,
     machineId,
+    deploymentId,
     meta: {
       targetFn: updateResult[0]?.targetFn,
       result,

--- a/control-plane/src/modules/observability/events.ts
+++ b/control-plane/src/modules/observability/events.ts
@@ -20,6 +20,7 @@ type Event = {
   type: EventTypes;
   jobId?: string;
   machineId?: string;
+  deploymentId?: string;
   service?: string;
   meta?: {
     targetFn?: string;
@@ -77,12 +78,12 @@ class EventWriterBuffer {
 
       const values = events.map(
         (e) =>
-          sql`(${ulid()}, ${e.clusterId}, ${e.type}, ${e.jobId ?? null}, ${e.machineId ?? null}, ${e.createdAt}, ${e.meta ?? null}, ${e.service ?? null})`,
+          sql`(${ulid()}, ${e.clusterId}, ${e.type}, ${e.jobId ?? null}, ${e.machineId ?? null}, ${e.createdAt}, ${e.meta ?? null}, ${e.service ?? null}, ${e.deploymentId ?? null})`,
       );
 
       const result = await data.db.execute(
         sql`
-          INSERT INTO events (id, cluster_id, type, job_id, machine_id, created_at, meta, service)
+          INSERT INTO events (id, cluster_id, type, job_id, machine_id, created_at, meta, service, deployment_id)
           VALUES ${sql.join(values, sql`,`)};
         `,
       );

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -49,6 +49,7 @@ export const router = s.router(contract, {
         owner,
         limit,
         machineId: request.headers["x-machine-id"],
+        deploymentId: request.headers["x-deployment-id"],
         ip: request.request.ip,
         service: request.body.service,
         definition: {

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -87,6 +87,7 @@ export const router = s.router(contract, {
       jobId,
       owner,
       machineId: request.headers["x-machine-id"] as string,
+      deploymentId: request.headers["x-deployment-id"] as string,
     });
 
     return {
@@ -325,6 +326,7 @@ export const router = s.router(contract, {
 
       events.write({
         machineId: request.headers["x-machine-id"],
+        deploymentId: request.headers["x-deployment-id"],
         clusterId: owner.clusterId,
         type: event.type,
         service: event.tags.service,

--- a/ts-core/src/contract.ts
+++ b/ts-core/src/contract.ts
@@ -97,6 +97,8 @@ export const definition = {
     path: "/jobs/:jobId/result",
     headers: z.object({
       authorization: z.string(),
+      "x-machine-id": z.string(),
+      "x-deployment-id": z.string().optional(),
     }),
     pathParams: z.object({
       jobId: z.string(),

--- a/ts-core/src/contract.ts
+++ b/ts-core/src/contract.ts
@@ -16,6 +16,7 @@ export const definition = {
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
+      "x-deployment-id": z.string().optional(),
     }),
     body: z.object({
       limit: z.coerce.number().default(1),
@@ -302,20 +303,26 @@ export const definition = {
     }),
     responses: {
       200: z.object({
-        start: z.date(),
-        stop: z.date(),
-        success: z.object({
-          count: z.array(z.object({ timestamp: z.date(), value: z.number() })),
-          avgExecutionTime: z.array(
-            z.object({ timestamp: z.date(), value: z.number() }),
-          ),
-        }),
-        failure: z.object({
-          count: z.array(z.object({ timestamp: z.date(), value: z.number() })),
-          avgExecutionTime: z.array(
-            z.object({ timestamp: z.date(), value: z.number() }),
-          ),
-        }),
+        summary: z.array(
+          z.object({
+            targetFn: z.string(),
+            resultType: z.string(),
+            count: z.number(),
+            avgExecutionTime: z.number(),
+            minExecutionTime: z.number(),
+            maxExecutionTime: z.number(),
+          }),
+        ),
+        timeseries: z.array(
+          z.object({
+            timeBin: z.string(),
+            serviceName: z.string(),
+            avgExecutionTime: z.number(),
+            totalJobResulted: z.number(),
+            totalJobStalled: z.number(),
+            rejectionCount: z.number(),
+          }),
+        ),
       }),
       401: z.undefined(),
       404: z.undefined(),
@@ -324,10 +331,7 @@ export const definition = {
       clusterId: z.string(),
     }),
     query: z.object({
-      start: z.coerce.date().optional(),
-      stop: z.coerce.date().optional(),
-      functionName: z.string().optional(),
-      serviceName: z.string().optional(),
+      serviceName: z.string(),
     }),
   },
   ingestClientEvents: {
@@ -336,6 +340,7 @@ export const definition = {
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
+      "x-deployment-id": z.string().optional(),
     }),
     responses: {
       204: z.undefined(),
@@ -361,11 +366,10 @@ export const definition = {
     responses: {
       200: z.array(
         z.object({
-          jobId: z.string(),
           type: z.string(),
-          meta: z.string().optional(),
+          meta: z.unknown(),
           machineId: z.string().nullable(),
-          timestamp: z.string(),
+          timestamp: z.date(),
           service: z.string().nullable(),
         }),
       ),
@@ -374,7 +378,94 @@ export const definition = {
     },
     query: z.object({
       jobId: z.string(),
-      interval: z.literal("-7d"),
+    }),
+  },
+  createDeployment: {
+    method: "POST",
+    path: "/clusters/:clusterId/service/:serviceName/deployments",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    body: z.undefined(),
+    responses: {
+      501: z.undefined(),
+      401: z.undefined(),
+      200: z.object({
+        id: z.string(),
+        packageUploadUrl: z.string(),
+        definitionUploadUrl: z.string(),
+        status: z.string(),
+      }),
+    },
+  },
+  getDeployment: {
+    method: "GET",
+    path: "/clusters/:clusterId/service/:serviceName/deployments/:deploymentId",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    body: z.undefined(),
+    responses: {
+      401: z.undefined(),
+      404: z.undefined(),
+      200: z.object({
+        id: z.string(),
+        packageUploadUrl: z.string(),
+        definitionUploadUrl: z.string(),
+        status: z.string(),
+      }),
+    },
+  },
+  releaseDeployment: {
+    method: "POST",
+    path: "/clusters/:clusterId/service/:serviceName/deployments/:deploymentId/release",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    body: z.undefined(),
+    responses: {
+      400: z.undefined(),
+      401: z.undefined(),
+      404: z.undefined(),
+      200: z.object({
+        id: z.string(),
+        packageUploadUrl: z.string(),
+        definitionUploadUrl: z.string(),
+        status: z.string(),
+      }),
+    },
+  },
+  setClusterSettings: {
+    method: "PUT",
+    path: "/clusters/:clusterId/settings",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    body: z.object({
+      predictiveRetriesEnabled: z.boolean(),
+    }),
+    responses: {
+      204: z.undefined(),
+      401: z.undefined(),
+    },
+    pathParams: z.object({
+      clusterId: z.string(),
+    }),
+  },
+  getClusterSettings: {
+    method: "GET",
+    path: "/clusters/:clusterId/settings",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    responses: {
+      200: z.object({
+        predictiveRetriesEnabled: z.boolean(),
+      }),
+      401: z.undefined(),
+    },
+    pathParams: z.object({
+      clusterId: z.string(),
     }),
   },
 } as const;


### PR DESCRIPTION
- Add `x-deployment-id` header to `/jobs-request` requests.
- Attach `deployment_id` to `machines` and `events`
- Set `DIFFERENTIAL_DEPLOYMENT_ID` to Lambda runtime environment.