### PR TITLE
fix: Clear CommonJS cache between invocations

### DIFF
--- a/cli/src/lib/package.ts
+++ b/cli/src/lib/package.ts
@@ -197,7 +197,8 @@ const buildIndex = async (entrypoint: string, outDir: string) => {
 
   fs.writeFileSync(
     indexFilePath,
-    `exports.handler = () => {require('${entrypoint}')};`,
+    `exports.handler = () => {Object.keys(require.cache).forEach((c) => delete require.cache[c])
+; require('${entrypoint}')};`,
     "utf-8",
   );
 };


### PR DESCRIPTION
Because our [Lambda entrypoint](https://github.com/differentialhq/differential/blob/main/cli/src/lib/package.ts#L200) relies on importing a service entrypoint to start each invocation, we are running into an issue when Lambda is [reusing the execution environment](https://docs.aws.amazon.com/lambda/latest/operatorguide/execution-environment.html) as the imports are cached and the entrypoint is not run again.

This is a temporary fix as, Ideally we do want to leverage the pre-warmed execution environment but we may need to re-think _how_ we start the service. i.e perhaps we accept a path to a module that exports the service and the entrypoint is responsible for calling `.listen()`.
