### PR TITLE
feat: Add CLI auth flow

### DIFF
--- a/admin/app/cli-auth/page.tsx
+++ b/admin/app/cli-auth/page.tsx
@@ -1,0 +1,16 @@
+import { auth } from "@clerk/nextjs";
+import { redirect } from "next/navigation";
+
+export default async function CliAuth() {
+  const { getToken } = await auth();
+
+  const token = await getToken();
+
+  if (!token) {
+    return null;
+  }
+
+  const url = new URL("http://localhost:9999");
+  url.searchParams.append("token", token);
+  return redirect(url.toString());
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,6 +17,7 @@
     "@ts-rest/core": "^3.28.0",
     "debug": "^4.3.4",
     "detective": "^5.2.1",
+    "tslib": "^2.6.2",
     "typescript": "^5.2.2",
     "ulid": "^2.3.0",
     "yargs": "^17.7.2",

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,0 +1,24 @@
+import { CommandModule, showHelp } from "yargs";
+import { startTokenFlow } from "../lib/auth";
+
+export const Auth: CommandModule = {
+  command: "auth",
+  describe: "Authenticate with the Differential API.",
+  builder: (yargs) =>
+    yargs.command({
+      command: "login",
+      describe: "Authenticate the Differential CLI.",
+      handler: () => {
+        startTokenFlow();
+      },
+    }),
+  handler: async ({ command }) => {
+    switch (command) {
+      case "login":
+        console.log("Authenticating the Differential CLI...");
+        break;
+      default:
+        showHelp();
+    }
+  },
+};

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,9 +4,12 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import { Deploy } from "./commands/deploy";
+import { Auth } from "./commands/auth";
 
 yargs(hideBin(process.argv))
   .scriptName("differential")
   .strict()
   .hide("version")
-  .command(Deploy).argv;
+  .demandCommand()
+  .command(Deploy)
+  .command(Auth).argv;

--- a/cli/src/lib/auth.ts
+++ b/cli/src/lib/auth.ts
@@ -1,0 +1,69 @@
+import os from "os";
+import path from "path";
+import fs from "fs";
+
+import http from "http";
+import { exec } from "child_process";
+
+const TOKEN_PATH = path.join(os.homedir(), ".differential", "credentials");
+export const storeToken = (token: string) => {
+  const TOKEN_PATH = path.join(os.homedir(), ".differential", "credentials");
+  const dir = path.dirname(TOKEN_PATH);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(TOKEN_PATH, token);
+};
+
+export const getToken = () => {
+  if (fs.existsSync(TOKEN_PATH)) {
+    return fs.readFileSync(TOKEN_PATH, { encoding: "utf-8" });
+  }
+  return null;
+};
+
+const AUTH_URL = "http://localhost:3000/cli-auth";
+export const startTokenFlow = () => {
+  if (process.platform === "darwin") {
+    exec(`open ${AUTH_URL}`);
+  } else {
+    console.log(`Please open your browser and navigate to ${AUTH_URL}`);
+  }
+
+  console.log("Listening at port 9999");
+  const server = http
+    .createServer((req, res) => {
+      const token = new URL(
+        req.url ?? "",
+        "http://localhost:9999",
+      ).searchParams.get("token");
+      if (token) {
+        storeToken(token);
+        console.log("The Differential CLI has been authenticated.");
+        const body = `
+      <html>
+        <script>
+          setTimeout(() => {
+            window.close();
+          }, 1000);
+        </script>
+        <body>
+          <h1>Authenticated!</h1>
+          <p>You can close this window now.</p>
+        </body>
+      </html>`;
+        res.write(body, () => res.end(() => server.close()));
+      } else {
+        console.error("Failed to authenticate.");
+        const body = `
+      <html>
+        <body>
+          <h1>Not authenticated</h1>
+          <p>Something went wrong. Please try again.</p>
+        </body>
+      </html>`;
+        res.write(body, () => res.end(() => server.close()));
+      }
+    })
+    .listen(9999);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "@ts-rest/core": "^3.28.0",
         "debug": "^4.3.4",
         "detective": "^5.2.1",
+        "tslib": "^2.6.2",
         "typescript": "^5.2.2",
         "ulid": "^2.3.0",
         "yargs": "^17.7.2",


### PR DESCRIPTION
- `differential auth login` will start listening at port 9999 and open the browser
- FE has a new `cli-auth` route which redirects checks authentication and redirects to localhost

