### PR TITLE
feat(cli): Use management token for authentication

### DIFF
--- a/cli/src/commands/deploy-create.ts
+++ b/cli/src/commands/deploy-create.ts
@@ -1,0 +1,82 @@
+import debug from "debug";
+
+import * as fs from "fs";
+import * as os from "os";
+
+import { CommandModule, argv } from "yargs";
+import { buildPackage } from "../lib/package";
+import { uploadPackage } from "../lib/upload";
+import { release } from "../lib/release";
+import { waitForDeploymentStatus } from "../lib/client";
+
+const log = debug("differential:cli:deploy:create");
+
+interface DeployCreateArgs {
+  entrypoint: string;
+  cluster: string;
+  service: string;
+}
+export const DeployCreate: CommandModule<{}, DeployCreateArgs> = {
+  command: "create",
+  describe: "Create a new Differential service deployment",
+  builder: (yargs) =>
+    yargs
+      .option("entrypoint", {
+        describe: "Path to service entrypoint file",
+        demandOption: true,
+        type: "string",
+      })
+      .option("cluster", {
+        describe: "Cluster ID",
+        demandOption: true,
+        type: "string",
+      })
+      .option("service", {
+        describe: "Service name",
+        demandOption: true,
+        type: "string",
+      }),
+  handler: async ({ entrypoint, cluster, service }) => {
+    log("Running deploy command", { argv });
+    const tmpDir = fs.mkdtempSync(os.tmpdir());
+    try {
+      const outDir = `${tmpDir}/out`;
+
+      console.log("⚙️   Building service...");
+      const { packagePath, definitionPath } = await buildPackage(
+        entrypoint,
+        outDir,
+      );
+      console.log("✅  Build complete");
+
+      console.log("📦  Uploading service...");
+      const deployment = await uploadPackage(
+        packagePath,
+        definitionPath,
+        cluster,
+        service,
+      );
+      console.log("✅  Upload complete");
+
+      console.log("☁️   Deploying service");
+      await release({
+        deploymentId: deployment.id,
+        serviceName: service,
+        clusterId: cluster,
+      });
+      await waitForDeploymentStatus(
+        deployment.id,
+        service,
+        cluster,
+        "active",
+        1000,
+      );
+      console.log(
+        `✅  Deployment complete, ${service}:${deployment.id} is now available!`,
+      );
+    } finally {
+      log("Cleaning up temporary directory", { tmpDir });
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  },
+};

--- a/cli/src/commands/deploy-info.ts
+++ b/cli/src/commands/deploy-info.ts
@@ -1,0 +1,44 @@
+import { CommandModule } from "yargs";
+import { client } from "../lib/client";
+
+interface DeployInfoArgs {
+  cluster: string;
+  service: string;
+  deployment: string;
+}
+export const DeployInfo: CommandModule<{}, DeployInfoArgs> = {
+  command: "info",
+  describe: "Display information about a Differential cloud deployment",
+  builder: (yargs) =>
+    yargs
+      .option("cluster", {
+        describe: "Cluster ID",
+        demandOption: true,
+        type: "string",
+      })
+      .option("service", {
+        describe: "Service name",
+        demandOption: true,
+        type: "string",
+      })
+      .option("deployment", {
+        describe: "Deployment ID",
+        demandOption: true,
+        type: "string",
+      }),
+  handler: async ({ cluster, service, deployment }) => {
+    const d = await client.getDeployment({
+      params: {
+        clusterId: cluster,
+        serviceName: service,
+        deploymentId: deployment,
+      },
+    });
+    if (d.status !== 200) {
+      console.error(`Failed to fetch deployment info: ${d.status}`);
+      return;
+    }
+
+    console.log(d.body);
+  },
+};

--- a/cli/src/commands/deploy.ts
+++ b/cli/src/commands/deploy.ts
@@ -1,86 +1,13 @@
-import debug from "debug";
+import { CommandModule, showHelp } from "yargs";
+import { DeployCreate } from "./deploy-create";
+import { DeployInfo } from "./deploy-info";
 
-import * as fs from "fs";
-import * as os from "os";
-
-import { CommandModule, argv } from "yargs";
-import { buildPackage } from "../lib/package";
-import { uploadPackage } from "../lib/upload";
-import { release } from "../lib/release";
-import { waitForDeploymentStatus } from "../lib/client";
-
-const log = debug("differential:cli:deploy");
-
-interface DeployArgs {
-  entrypoint: string;
-  cluster: string;
-  service: string;
-}
-export const Deploy: CommandModule<{}, DeployArgs> = {
-  command: "deploy",
-  describe: "Deploy a service to differential cloud",
-  builder: (yargs) =>
-    yargs
-      .option("entrypoint", {
-        describe: "Path to service entrypoint file",
-        demandOption: true,
-        type: "string",
-      })
-      .option("cluster", {
-        describe: "Cluster ID",
-        demandOption: true,
-        type: "string",
-      })
-      .option("service", {
-        describe: "Service name",
-        demandOption: true,
-        type: "string",
-      }),
-  handler: async ({ entrypoint, cluster, service }) => {
-    log("Running deploy command", { argv });
-    if (!process.env.DIFFERENTIAL_API_TOKEN) {
-      throw new Error("DIFFERENTIAL_API_TOKEN is required.");
-    }
-
-    const tmpDir = fs.mkdtempSync(os.tmpdir());
-    try {
-      const outDir = `${tmpDir}/out`;
-
-      console.log("⚙️   Building service...");
-      const { packagePath, definitionPath } = await buildPackage(
-        entrypoint,
-        outDir,
-      );
-      console.log("✅  Build complete");
-
-      console.log("📦  Uploading service...");
-      const deployment = await uploadPackage(
-        packagePath,
-        definitionPath,
-        cluster,
-        service,
-      );
-      console.log("✅  Upload complete");
-
-      console.log("☁️   Deploying service");
-      await release({
-        deploymentId: deployment.id,
-        serviceName: service,
-        clusterId: cluster,
-      });
-      await waitForDeploymentStatus(
-        deployment.id,
-        service,
-        cluster,
-        "active",
-        1000,
-      );
-      console.log(
-        `✅  Deployment complete, ${service}:${deployment.id} is now available!`,
-      );
-    } finally {
-      log("Cleaning up temporary directory", { tmpDir });
-      fs.rmSync(tmpDir, { recursive: true });
-    }
+export const Deploy: CommandModule = {
+  command: "deployments",
+  aliases: ["deploy", "d"],
+  describe: "Manage Differential cloud deployments",
+  builder: (yargs) => yargs.command(DeployCreate).command(DeployInfo),
+  handler: async () => {
+    showHelp();
   },
 };

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -5,11 +5,22 @@ import { hideBin } from "yargs/helpers";
 
 import { Deploy } from "./commands/deploy";
 import { Auth } from "./commands/auth";
+import { getToken } from "./lib/auth";
 
-yargs(hideBin(process.argv))
+const cli = yargs(hideBin(process.argv))
   .scriptName("differential")
   .strict()
   .hide("version")
   .demandCommand()
-  .command(Deploy)
-  .command(Auth).argv;
+  .command(Auth);
+
+const authenticated = getToken();
+if (authenticated) {
+  cli.command(Deploy);
+} else {
+  console.log(
+    "Diffential CLI is not authenticated. Please run `differential auth login` to authenticate.",
+  );
+}
+
+cli.argv;

--- a/cli/src/lib/client.ts
+++ b/cli/src/lib/client.ts
@@ -1,10 +1,11 @@
 import { initClient, tsRestFetchApi } from "@ts-rest/core";
 import { contract } from "../client/contract";
 
+import { getToken } from "../lib/auth";
 export const client = initClient(contract, {
   baseUrl: process.env.DIFFERENTIAL_API_URL || "https://api.differential.dev",
   baseHeaders: {
-    authorization: `Bearer ${process.env.DIFFERENTIAL_API_TOKEN}`,
+    authorization: `Bearer ${getToken()}`,
   },
   api: tsRestFetchApi,
 });

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -231,6 +231,7 @@ export const router = s.router(contract, {
     };
   },
   createClusterForUser: async (request) => {
+    // TODO: Validate token
     const managementToken = request.headers.authorization.split(" ")[1];
 
     const { description } = request.body;
@@ -246,9 +247,12 @@ export const router = s.router(contract, {
     };
   },
   getClusterDetailsForUser: async (request) => {
-    await routingHelpers.validateManagementAccess(request);
-
-    const managementToken = request.headers.authorization.split(" ")[1];
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
+      return {
+        status: 401,
+      };
+    }
 
     const { clusterId } = request.params;
 
@@ -268,7 +272,12 @@ export const router = s.router(contract, {
     };
   },
   getClusterServiceDetailsForUser: async (request) => {
-    await routingHelpers.validateManagementAccess(request);
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
+      return {
+        status: 401,
+      };
+    }
 
     const { clusterId, serviceName } = request.params;
 
@@ -293,7 +302,12 @@ export const router = s.router(contract, {
     };
   },
   getMetrics: async (request) => {
-    await routingHelpers.validateManagementAccess(request);
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
+      return {
+        status: 401,
+      };
+    }
 
     // TODO: Validate serviceName and functionName
     // We don't currently store and service/function names in the database to validate against.
@@ -343,7 +357,12 @@ export const router = s.router(contract, {
     };
   },
   getActivity: async (request) => {
-    await routingHelpers.validateManagementAccess(request);
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
+      return {
+        status: 401,
+      };
+    }
 
     const { clusterId } = request.params;
 
@@ -360,18 +379,18 @@ export const router = s.router(contract, {
     };
   },
   createDeployment: async (request) => {
-    const owner = await auth.jobOwnerHash(request.headers.authorization);
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
+      return {
+        status: 401,
+      };
+    }
+
     const { clusterId, serviceName } = request.params;
 
     if (UPLOAD_BUCKET === undefined) {
       return {
         status: 501,
-      };
-    }
-
-    if (!owner || owner.clusterId !== clusterId || !owner.cloudEnabled) {
-      return {
-        status: 401,
       };
     }
 
@@ -386,33 +405,39 @@ export const router = s.router(contract, {
     };
   },
   getDeployment: async (request) => {
-    const owner = await auth.jobOwnerHash(request.headers.authorization);
-    const { clusterId, deploymentId } = request.params;
-
-    if (!owner || owner.clusterId !== clusterId || !owner.cloudEnabled) {
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
       return {
         status: 401,
+      };
+    }
+
+    const { clusterId, deploymentId } = request.params;
+    const deployment = await getDeployment(deploymentId);
+
+    if (!deployment || deployment.clusterId !== clusterId) {
+      return {
+        status: 404,
       };
     }
 
     return {
       status: 200,
-      body: await getDeployment(deploymentId),
+      body: deployment,
     };
   },
   releaseDeployment: async (request) => {
-    const owner = await auth.jobOwnerHash(request.headers.authorization);
-    const { clusterId, deploymentId } = request.params;
-
-    if (!owner || owner.clusterId !== clusterId || !owner.cloudEnabled) {
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
       return {
         status: 401,
       };
     }
 
+    const { clusterId, deploymentId } = request.params;
     const deployment = await getDeployment(deploymentId);
 
-    if (!deployment) {
+    if (!deployment || deployment.clusterId !== clusterId) {
       return {
         status: 404,
       };
@@ -433,7 +458,12 @@ export const router = s.router(contract, {
     };
   },
   setClusterSettings: async (request) => {
-    await routingHelpers.validateManagementAccess(request);
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
+      return {
+        status: 401,
+      };
+    }
 
     const { clusterId } = request.params;
 
@@ -449,7 +479,12 @@ export const router = s.router(contract, {
     };
   },
   getClusterSettings: async (request) => {
-    await routingHelpers.validateManagementAccess(request);
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
+      return {
+        status: 401,
+      };
+    }
 
     const { clusterId } = request.params;
 

--- a/control-plane/src/modules/routing-helpers.ts
+++ b/control-plane/src/modules/routing-helpers.ts
@@ -7,18 +7,17 @@ export const validateManagementAccess = async (request: {
   params: {
     clusterId: string;
   };
-}) => {
+}): Promise<boolean> => {
   const managementToken = request.headers.authorization.split(" ")[1];
 
-  const hasAccess = await management.hasAccessToCluster({
-    managementToken,
-    clusterId: request.params.clusterId,
-  });
-
-  if (!hasAccess) {
-    return {
-      status: 403,
-      body: undefined,
-    };
+  try {
+    const clusterAccess = await management.hasAccessToCluster({
+      managementToken,
+      clusterId: request.params.clusterId,
+    });
+    return clusterAccess;
+  } catch {
+    console.error("Error validating management token", managementToken);
+    return false;
   }
 };


### PR DESCRIPTION
- Use management token from `differential auth login` for ts-rest client requests
- Move commands around `differential deploy / d create`
- Add `differential deploy info` command
- Return failures when management routes don't have access to a requested cluster