### PR TITLE
feat(cli): Add cluster management commands

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@inquirer/prompts": "^4.0.0",
     "@ts-rest/core": "^3.28.0",
     "debug": "^4.3.4",
     "detective": "^5.2.1",

--- a/cli/src/commands/clusters-create.ts
+++ b/cli/src/commands/clusters-create.ts
@@ -1,0 +1,29 @@
+import { CommandModule } from "yargs";
+import { client } from "../lib/client";
+
+interface ClusterCreateArgs {
+  description?: string;
+}
+export const ClusterCreate: CommandModule<{}, ClusterCreateArgs> = {
+  command: "create",
+  describe: "Create a new Differential cluster",
+  builder: (yargs) =>
+    yargs.option("description", {
+      describe: "Cluster Description",
+      demandOption: false,
+      type: "string",
+    }),
+  handler: async ({ description }) => {
+    const d = await client.createClusterForUser({
+      body: {
+        description: description ?? "CLI Created Cluster",
+      },
+    });
+    if (d.status !== 204) {
+      console.error(`Failed to create cluster: ${d.status}`);
+      return;
+    }
+
+    console.log("Cluster created successfully");
+  },
+};

--- a/cli/src/commands/clusters-info.ts
+++ b/cli/src/commands/clusters-info.ts
@@ -1,0 +1,41 @@
+import { CommandModule } from "yargs";
+import { client } from "../lib/client";
+import { selectCluster } from "../utils";
+
+interface ClusterInfoArgs {
+  cluster?: string;
+}
+export const ClusterInfo: CommandModule<{}, ClusterInfoArgs> = {
+  command: "info",
+  describe: "Display information about a Differential cluster",
+  builder: (yargs) =>
+    yargs.option("cluster", {
+      describe: "Cluster ID",
+      demandOption: false,
+      type: "string",
+    }),
+  handler: async ({ cluster }) => {
+    if (!cluster) {
+      cluster = await selectCluster();
+      if (!cluster) {
+        console.log("No cluster selected");
+        return;
+      }
+    }
+
+    getClusterDetails(cluster);
+  },
+};
+
+const getClusterDetails = async (clusterId: string) => {
+  const d = await client.getClusterDetailsForUser({
+    params: {
+      clusterId,
+    },
+  });
+  if (d.status !== 200) {
+    console.error(`Failed to get cluster details: ${d.status}`);
+    return;
+  }
+  console.log(d.body);
+};

--- a/cli/src/commands/clusters-list.ts
+++ b/cli/src/commands/clusters-list.ts
@@ -1,0 +1,25 @@
+import { CommandModule } from "yargs";
+import { client } from "../lib/client";
+
+interface ClusterCreateArgs {
+  description?: string;
+}
+export const ClusterList: CommandModule<{}, ClusterCreateArgs> = {
+  command: "list",
+  aliases: ["ls"],
+  describe: "List Differential clusters",
+  handler: async () => {
+    const d = await client.getClustersForUser();
+    if (d.status !== 200) {
+      console.error(`Failed to list clusters: ${d.status}`);
+      return;
+    }
+
+    if (!d.body) {
+      console.log("No clusters found");
+      return;
+    }
+
+    console.log(d.body);
+  },
+};

--- a/cli/src/commands/clusters-open.ts
+++ b/cli/src/commands/clusters-open.ts
@@ -1,0 +1,28 @@
+import { CommandModule } from "yargs";
+import { openBrowser, selectCluster } from "../utils";
+import { BASE_URL } from "../constants";
+
+interface ClusterOpenArgs {
+  cluster?: string;
+}
+export const ClusterOpen: CommandModule<{}, ClusterOpenArgs> = {
+  command: "open",
+  describe: "Open a Differential cluster in the console",
+  builder: (yargs) =>
+    yargs.option("cluster", {
+      describe: "Cluster ID",
+      demandOption: false,
+      type: "string",
+    }),
+  handler: async ({ cluster }) => {
+    if (!cluster) {
+      cluster = await selectCluster();
+      if (!cluster) {
+        console.log("No cluster selected");
+        return;
+      }
+    }
+
+    openBrowser(`${BASE_URL}/clusters/${cluster}`);
+  },
+};

--- a/cli/src/commands/clusters.ts
+++ b/cli/src/commands/clusters.ts
@@ -1,0 +1,20 @@
+import { CommandModule, showHelp } from "yargs";
+import { ClusterCreate } from "./clusters-create";
+import { ClusterList } from "./clusters-list";
+import { ClusterOpen } from "./clusters-open";
+import { ClusterInfo } from "./clusters-info";
+
+export const Clusters: CommandModule = {
+  command: "clusters",
+  aliases: ["c"],
+  describe: "Manage Differential clusters",
+  builder: (yargs) =>
+    yargs
+      .command(ClusterCreate)
+      .command(ClusterList)
+      .command(ClusterOpen)
+      .command(ClusterInfo),
+  handler: async () => {
+    showHelp();
+  },
+};

--- a/cli/src/constants.ts
+++ b/cli/src/constants.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = "https://console.differential.dev";

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import { hideBin } from "yargs/helpers";
 import { Deploy } from "./commands/deploy";
 import { Auth } from "./commands/auth";
 import { getToken } from "./lib/auth";
+import { Clusters } from "./commands/clusters";
 
 const cli = yargs(hideBin(process.argv))
   .scriptName("differential")
@@ -16,7 +17,7 @@ const cli = yargs(hideBin(process.argv))
 
 const authenticated = getToken();
 if (authenticated) {
-  cli.command(Deploy);
+  cli.command(Deploy).command(Clusters);
 } else {
   console.log(
     "Diffential CLI is not authenticated. Please run `differential auth login` to authenticate.",

--- a/cli/src/lib/auth.ts
+++ b/cli/src/lib/auth.ts
@@ -3,7 +3,8 @@ import path from "path";
 import fs from "fs";
 
 import http from "http";
-import { exec } from "child_process";
+import { openBrowser } from "../utils";
+import { BASE_URL } from "../constants";
 
 const TOKEN_PATH = path.join(os.homedir(), ".differential", "credentials");
 export const storeToken = (token: string) => {
@@ -22,13 +23,9 @@ export const getToken = () => {
   return null;
 };
 
-const AUTH_URL = "http://localhost:3000/cli-auth";
+const AUTH_URL = `${BASE_URL}/cli-auth`;
 export const startTokenFlow = () => {
-  if (process.platform === "darwin") {
-    exec(`open ${AUTH_URL}`);
-  } else {
-    console.log(`Please open your browser and navigate to ${AUTH_URL}`);
-  }
+  openBrowser(AUTH_URL);
 
   console.log("Listening at port 9999");
   const server = http

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1,0 +1,31 @@
+import { exec } from "child_process";
+import { client } from "./lib/client";
+import { select } from "@inquirer/prompts";
+
+export const openBrowser = async (url: string) => {
+  if (process.platform === "darwin") {
+    exec(`open ${url}`);
+  } else if (process.platform === "linux") {
+    exec(`xdg-open ${url}`);
+  } else {
+    console.log(`Please open your browser and navigate to ${url}`);
+  }
+};
+
+export const selectCluster = async (): Promise<string | undefined> => {
+  const d = await client.getClustersForUser();
+  if (d.status !== 200) {
+    console.error(`Failed to get clusters: ${d.status}`);
+    return;
+  }
+
+  if (!d.body) {
+    console.log("No clusters found");
+    return;
+  }
+
+  return select({
+    message: "Select a cluster",
+    choices: d.body.map((c: any) => ({ name: c.id, value: c.id })),
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
       "version": "3.12.2",
       "license": "ISC",
       "dependencies": {
+        "@inquirer/prompts": "^4.0.0",
         "@ts-rest/core": "^3.28.0",
         "debug": "^4.3.4",
         "detective": "^5.2.1",
@@ -4040,6 +4041,285 @@
       "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client/-/influxdb-client-1.33.2.tgz",
       "integrity": "sha512-RT5SxH+grHAazo/YK3UTuWK/frPWRM0N7vkrCUyqVprDgQzlLP+bSK4ak2Jv3QVF/pazTnsxWjvtKZdwskV5Xw=="
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.0.0.tgz",
+      "integrity": "sha512-z+MRAXQaZCe5jzqwW488jFrRsT8Rbwr3e0wNkbPBhLr5oVeWcSowFidLcCHca+gcLJMHEVMYqAE7J90UtoWyIw==",
+      "dependencies": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "figures": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.0.0.tgz",
+      "integrity": "sha512-LHeuYP1D8NmQra1eR4UqvZMXwxEdDXyElJmmZfU44xdNLL6+GcQBS0uE16vyfZVjH8c22p9e+DStROfE/hyHrg==",
+      "dependencies": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-g13W5yEt9r1sEVVriffJqQ8GWy94OnfxLCreNSOTw0HPVcszmc/If1KIf7YBmlwtX4klmvwpZHnQpl3N7VX2xA==",
+      "dependencies": {
+        "@inquirer/type": "^1.2.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.11.16",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "figures": "^3.2.0",
+        "mute-stream": "^1.0.0",
+        "run-async": "^3.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.0.0.tgz",
+      "integrity": "sha512-0n3agxb1X23A/lx+MI5sV6s/qeywGr4xmKAzZS7ZhToee7L/6DXotWa/VvvwNEoBT0mSuk9SDIAoQ0zLkJmpHg==",
+      "dependencies": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.0.0.tgz",
+      "integrity": "sha512-2VETEz+RyRrIeBwULKc5o+PJzKqbsibyT6IY0oP0XvM/17flO6eW7P+rdGCAvFP6g2hKieIH23ZVrcgsosb1/g==",
+      "dependencies": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0",
+        "chalk": "^4.1.2",
+        "figures": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.0.0.tgz",
+      "integrity": "sha512-qOjxSHLzqp/u6TvK7UtidPERoCa6BSSKyKG17aEaSOBl9uAQ4XIIqs9TtcEqwDloakarWS6xxTfR0sE1qvLwIQ==",
+      "dependencies": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.0.0.tgz",
+      "integrity": "sha512-PlUek3wTMiGZothmmGIL4OBLo+rDSCxqIUHsyroyM/+AnR3xr5NHMM0/5z6CuptpJs1ZbQewqslaNi7k6goWMw==",
+      "dependencies": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-4.0.0.tgz",
+      "integrity": "sha512-IS4FMj4k+3gxlvKCL1ibSEc3mMnpZ4eFeKlv0ZOo0AMWFxLSvCUT3xOw72N+UTeARK7cbwXxpt7KHcZ5q/RV0Q==",
+      "dependencies": {
+        "@inquirer/checkbox": "^2.0.0",
+        "@inquirer/confirm": "^3.0.0",
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/editor": "^2.0.0",
+        "@inquirer/expand": "^2.0.0",
+        "@inquirer/input": "^2.0.0",
+        "@inquirer/password": "^2.0.0",
+        "@inquirer/rawlist": "^2.0.0",
+        "@inquirer/select": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.0.0.tgz",
+      "integrity": "sha512-o4jHJBAvknVE6K15zX8AuLMemb1eN1EL0l+BIbJ2JgtpoU2zSuLf6jT98omvtWk/gbaowjw7RLsW7X5F+G19KA==",
+      "dependencies": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.0.0.tgz",
+      "integrity": "sha512-ZxWP1gHbReAH6HdoNQRV/9W/UjgKSeiiQX2DxJ6w3GDiQeC3fRAL+lukuMM+QGteGqaTjWwIEWhPLvgbGIrRgg==",
+      "dependencies": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "figures": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-/vvkUkYhrjbm+RolU7V1aUFDydZVKNKqKHR5TsE+j5DXgXFwrsOPcoGUJ02K0O7q7O53CU2DOTMYCHeGZ25WHA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -7425,10 +7705,18 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
-      "version": "20.11.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
-      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
+      "version": "20.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
+      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -7543,6 +7831,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -8929,8 +9222,7 @@
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -11946,7 +12238,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
       "dependencies": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -11960,7 +12251,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -12146,7 +12436,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -13124,7 +13413,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -17954,7 +18242,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20248,8 +20535,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -22942,7 +23228,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",


### PR DESCRIPTION
Adds cluster management commands `list`, `info`, `open`, `create`.

<img width="777" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/4b2616ca-bc30-4247-ab56-c7e7330c609c">

<img width="870" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/0c395316-1bff-472b-80a9-4921a45277ec">
