### PR TITLE
feat: Extended CLI token

### DIFF
--- a/admin/app/cli-auth/page.tsx
+++ b/admin/app/cli-auth/page.tsx
@@ -4,7 +4,9 @@ import { redirect } from "next/navigation";
 export default async function CliAuth() {
   const { getToken } = await auth();
 
-  const token = await getToken();
+  const token = await getToken({
+    template: "extended-cli-token",
+  });
 
   if (!token) {
     return null;


### PR DESCRIPTION
Passes the [Clerk getToken()](https://clerk.com/docs/references/backend/sessions/get-token#get-token) call a reference to a custom template `extended-cli-token`