### PR TITLE
feat(cli): Allow arbitrary service name

### DIFF
--- a/cli/src/commands/deploy-create.ts
+++ b/cli/src/commands/deploy-create.ts
@@ -49,7 +49,7 @@ export const DeployCreate: CommandModule<{}, DeployCreateArgs> = {
     }
 
     if (!service) {
-      service = await selectService(cluster);
+      service = await selectService(cluster, true);
       if (!service) {
         console.log("No service selected");
         return;


### PR DESCRIPTION
Allow an arbitrary service name to be entered as part of deployment creation.
<img width="522" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/c4cdbea8-95fb-4dda-a833-d270ee89787e">
<img width="523" alt="image" src="https://github.com/differentialhq/differential/assets/9162298/5e423aeb-9c72-4f2f-b3d9-ae9b98c6cd5e">

