### PR TITLE
feat: Cleanup asset upload behaviour

### DIFF
--- a/cli/src/client/contract.ts
+++ b/cli/src/client/contract.ts
@@ -414,9 +414,8 @@ export const definition = {
     responses: {
       501: z.undefined(),
       401: z.undefined(),
-      200: z.object({
+      201: z.object({
         id: z.string(),
-        packageUploadUrl: z.string(),
         status: z.string(),
       }),
     },
@@ -474,7 +473,7 @@ export const definition = {
       }),
     },
   },
-  createClientLibrary: {
+  createClientLibraryVersion: {
     method: "POST",
     path: "/clusters/:clusterId/client-libraries",
     headers: z.object({
@@ -484,10 +483,28 @@ export const definition = {
     responses: {
       501: z.undefined(),
       401: z.undefined(),
-      200: z.object({
+      201: z.object({
         id: z.string(),
-        packageUploadUrl: z.string(),
+        version: z.string(),
       }),
+    },
+  },
+  createAsset: {
+    method: "POST",
+    path: "/clusters/:clusterId/assets",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    body: z.object({
+      type: z.enum(["client_library", "service_bundle"]),
+      target: z.string(),
+    }),
+    responses: {
+      201: z.object({
+        presignedUrl: z.string(),
+      }),
+      400: z.undefined(),
+      401: z.undefined(),
     },
   },
   setClusterSettings: {

--- a/control-plane/drizzle/0043_closed_weapon_omega.sql
+++ b/control-plane/drizzle/0043_closed_weapon_omega.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS "client_library_versions" (
+	"id" varchar(1024) NOT NULL,
+	"cluster_id" varchar NOT NULL,
+	"version" varchar(1024) NOT NULL,
+	"asset_upload_id" varchar(1024),
+	CONSTRAINT client_library_versions_cluster_id_id PRIMARY KEY("cluster_id","id")
+);
+--> statement-breakpoint
+ALTER TABLE "deployments" ALTER COLUMN "asset_upload_id" DROP NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "client_library_versions" ADD CONSTRAINT "client_library_versions_cluster_id_clusters_id_fk" FOREIGN KEY ("cluster_id") REFERENCES "clusters"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "client_library_versions" ADD CONSTRAINT "client_library_versions_asset_upload_id_asset_uploads_id_fk" FOREIGN KEY ("asset_upload_id") REFERENCES "asset_uploads"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/control-plane/drizzle/meta/0043_snapshot.json
+++ b/control-plane/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,755 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "0e8fa861-884d-4f4e-8d54-afd8bfd9176b",
+  "prevId": "cbd07861-92f6-4b68-89f3-c8f522ed2bd9",
+  "tables": {
+    "asset_uploads": {
+      "name": "asset_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "client_library_versions": {
+      "name": "client_library_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_upload_id": {
+          "name": "asset_upload_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "client_library_versions_cluster_id_clusters_id_fk": {
+          "name": "client_library_versions_cluster_id_clusters_id_fk",
+          "tableFrom": "client_library_versions",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "client_library_versions_asset_upload_id_asset_uploads_id_fk": {
+          "name": "client_library_versions_asset_upload_id_asset_uploads_id_fk",
+          "tableFrom": "client_library_versions",
+          "tableTo": "asset_uploads",
+          "columnsFrom": [
+            "asset_upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "client_library_versions_cluster_id_id": {
+          "name": "client_library_versions_cluster_id_id",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_secret": {
+          "name": "api_secret",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "wake_up_config": {
+          "name": "wake_up_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_enabled": {
+          "name": "cloud_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "predictive_retries_enabled": {
+          "name": "predictive_retries_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "retry_on_stall_enabled": {
+          "name": "retry_on_stall_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployment_notifications": {
+      "name": "deployment_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_notifications_deployment_id_deployments_id_fk": {
+          "name": "deployment_notifications_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_notifications",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployment_provider_config": {
+      "name": "deployment_provider_config",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "asset_upload_id": {
+          "name": "asset_upload_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployments_cluster_id_clusters_id_fk": {
+          "name": "deployments_cluster_id_clusters_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployments_asset_upload_id_asset_uploads_id_fk": {
+          "name": "deployments_asset_upload_id_asset_uploads_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "asset_uploads",
+          "columnsFrom": [
+            "asset_upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_cluster_id_clusters_id_fk": {
+          "name": "events_cluster_id_clusters_id_fk",
+          "tableFrom": "events",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_job_id_jobs_id_fk": {
+          "name": "events_job_id_jobs_id_fk",
+          "tableFrom": "events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_deployment_id_deployments_id_fk": {
+          "name": "events_deployment_id_deployments_id_fk",
+          "tableFrom": "events",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_machine_id_cluster_id_machines_id_cluster_id_fk": {
+          "name": "events_machine_id_cluster_id_machines_id_cluster_id_fk",
+          "tableFrom": "events",
+          "tableTo": "machines",
+          "columnsFrom": [
+            "machine_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "cluster_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_hash": {
+          "name": "owner_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_args": {
+          "name": "target_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executing_machine_id": {
+          "name": "executing_machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_attempts": {
+          "name": "remaining_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resulted_at": {
+          "name": "resulted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "function_execution_time_ms": {
+          "name": "function_execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_interval_seconds": {
+          "name": "timeout_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "predicted_to_be_retryable": {
+          "name": "predicted_to_be_retryable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicted_to_be_retryable_reason": {
+          "name": "predicted_to_be_retryable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predictive_retry_count": {
+          "name": "predictive_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jobs_owner_hash_target_fn_idempotency_key": {
+          "name": "jobs_owner_hash_target_fn_idempotency_key",
+          "columns": [
+            "owner_hash",
+            "target_fn",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "jobs_id_unique": {
+          "name": "jobs_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "machines_id_cluster_id": {
+          "name": "machines_id_cluster_id",
+          "columns": [
+            "id",
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_provider": {
+          "name": "deployment_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_cluster_id_clusters_id_fk": {
+          "name": "services_cluster_id_clusters_id_fk",
+          "tableFrom": "services",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "services_cluster_id_service": {
+          "name": "services_cluster_id_service",
+          "columns": [
+            "cluster_id",
+            "service"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/control-plane/drizzle/meta/_journal.json
+++ b/control-plane/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1708640616645,
       "tag": "0042_kind_lester",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "5",
+      "when": 1708737200211,
+      "tag": "0043_closed_weapon_omega",
+      "breakpoints": true
     }
   ]
 }

--- a/control-plane/src/modules/assets.test.ts
+++ b/control-plane/src/modules/assets.test.ts
@@ -1,0 +1,170 @@
+import * as data from "./data";
+import { ulid } from "ulid";
+import { createAssetUploadWithTarget } from "./assets";
+import { createOwner } from "./test/util";
+import { getPresignedURL } from "./s3";
+
+jest.mock("./s3", () => ({
+  UPLOAD_BUCKET: "mockedBucket",
+  getPresignedURL: jest.fn().mockResolvedValue("mockedPresignedURL"),
+}));
+
+describe("createAssetUploadWithTarget", () => {
+  let cluster1: string;
+  let cluster2: string;
+
+  beforeAll(async () => {
+    cluster1 = (await createOwner()).clusterId;
+    cluster2 = (await createOwner()).clusterId;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should create a client library asset upload", async () => {
+    const lib = await data.db
+      .insert(data.clientLibraryVersions)
+      .values({
+        id: ulid(),
+        cluster_id: cluster1,
+        version: "1.0.0",
+      })
+      .returning({
+        id: data.clientLibraryVersions.id,
+      });
+
+    const type = "client_library";
+    const result = await createAssetUploadWithTarget({
+      target: lib[0].id,
+      clusterId: cluster1,
+      type,
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toBe("mockedPresignedURL");
+
+    expect(getPresignedURL).toHaveBeenCalledWith(
+      "mockedBucket",
+      expect.stringContaining(`${type}/`),
+    );
+  });
+
+  it("should create a service bundle asset upload", async () => {
+    const deployment = await data.db
+      .insert(data.deployments)
+      .values({
+        id: ulid(),
+        cluster_id: cluster1,
+        service: "mock",
+        provider: "mock",
+      })
+      .returning({
+        id: data.deployments.id,
+      });
+
+    const type = "service_bundle";
+    const result = await createAssetUploadWithTarget({
+      target: deployment[0].id,
+      clusterId: cluster1,
+      type,
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toBe("mockedPresignedURL");
+
+    expect(getPresignedURL).toHaveBeenCalledWith(
+      "mockedBucket",
+      expect.stringContaining(`${type}/`),
+    );
+  });
+
+  it("should fail with asset upload exists for target", async () => {
+    const deployment = await data.db
+      .insert(data.deployments)
+      .values({
+        id: ulid(),
+        cluster_id: cluster1,
+        service: "mock",
+        provider: "mock",
+      })
+      .returning({
+        id: data.deployments.id,
+      });
+
+    const type = "service_bundle";
+    const result = await createAssetUploadWithTarget({
+      target: deployment[0].id,
+      clusterId: cluster1,
+      type,
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toBe("mockedPresignedURL");
+
+    const result2 = createAssetUploadWithTarget({
+      target: deployment[0].id,
+      clusterId: cluster1,
+      type,
+    });
+
+    await expect(result2).rejects.toEqual(
+      new Error(`Could not create asset upload for target ${deployment[0].id}`),
+    );
+  });
+
+  it("should fail when target is for another cluster", async () => {
+    const deployment = await data.db
+      .insert(data.deployments)
+      .values({
+        id: ulid(),
+        cluster_id: cluster1,
+        service: "mock",
+        provider: "mock",
+      })
+      .returning({
+        id: data.deployments.id,
+      });
+
+    const type = "service_bundle";
+    const target = deployment[0].id;
+
+    const result = createAssetUploadWithTarget({
+      clusterId: cluster2,
+      target,
+      type,
+    });
+
+    await expect(result).rejects.toEqual(
+      new Error(`Could not find deployment for target ${target}`),
+    );
+  });
+
+  it("should fail when client library version doesn't exist", async () => {
+    const target = ulid();
+    const type = "client_library";
+    const result = createAssetUploadWithTarget({
+      clusterId: cluster1,
+      target,
+      type,
+    });
+
+    await expect(result).rejects.toEqual(
+      new Error(`Could not find client version for target ${target}`),
+    );
+  });
+
+  it("should fail when deployment doesn't exist", async () => {
+    const target = ulid();
+    const type = "service_bundle";
+    const result = createAssetUploadWithTarget({
+      clusterId: cluster1,
+      target,
+      type,
+    });
+
+    await expect(result).rejects.toEqual(
+      new Error(`Could not find deployment for target ${target}`),
+    );
+  });
+});

--- a/control-plane/src/modules/assets.ts
+++ b/control-plane/src/modules/assets.ts
@@ -1,0 +1,121 @@
+import * as data from "./data";
+import { ulid } from "ulid";
+import { and, eq } from "drizzle-orm";
+import { UPLOAD_BUCKET, getPresignedURL } from "./s3";
+
+export type AssetType = "client_library" | "service_bundle";
+
+export const createAssetUploadWithTarget = async (
+  target: string,
+  clusterId: string,
+  type: AssetType,
+): Promise<string | null> => {
+  const id = ulid();
+  const key = `${type}/${id}`;
+  if (!UPLOAD_BUCKET) {
+    throw new Error("Upload bucket not configured");
+  }
+  const bucket = UPLOAD_BUCKET;
+
+  switch (type) {
+    case "client_library": {
+      const version = await data.db
+        .select({
+          version: data.clientLibraryVersions.version,
+        })
+        .from(data.clientLibraryVersions)
+        .where(
+          and(
+            eq(data.clientLibraryVersions.cluster_id, clusterId),
+            eq(data.clientLibraryVersions.id, target),
+          ),
+        );
+
+      if (version.length == 0) {
+        console.warn("Could not find client version for target", {
+          target,
+          clusterId,
+        });
+        return null;
+      }
+
+      await data.db.transaction(async (tx) => {
+        await tx
+          .insert(data.assetUploads)
+          .values({
+            id,
+            type: type,
+            bucket: bucket,
+            key: key,
+          })
+          .returning({
+            id: data.assetUploads.id,
+          });
+
+        await tx
+          .update(data.clientLibraryVersions)
+          .set({
+            asset_upload_id: id,
+          })
+          .where(
+            and(
+              eq(data.clientLibraryVersions.cluster_id, clusterId),
+              eq(data.clientLibraryVersions.id, target),
+            ),
+          );
+      });
+      break;
+    }
+    case "service_bundle": {
+      const deployment = await data.db
+        .select({
+          id: data.deployments.id,
+        })
+        .from(data.deployments)
+        .where(
+          and(
+            eq(data.deployments.cluster_id, clusterId),
+            eq(data.deployments.id, target),
+          ),
+        );
+
+      if (deployment.length == 0) {
+        console.warn("Could not find deployment for target", {
+          target,
+          clusterId,
+        });
+        return null;
+      }
+
+      await data.db.transaction(async (tx) => {
+        await tx
+          .insert(data.assetUploads)
+          .values({
+            id,
+            type: type,
+            bucket: bucket,
+            key: key,
+          })
+          .returning({
+            id: data.assetUploads.id,
+          });
+
+        await tx
+          .update(data.deployments)
+          .set({
+            asset_upload_id: id,
+          })
+          .where(eq(data.deployments.id, target));
+      });
+      break;
+    }
+    default: {
+      console.warn("Invalid asset type provided", {
+        type,
+      });
+      return null;
+    }
+  }
+
+  return getPresignedURL(bucket, key);
+};

--- a/control-plane/src/modules/assets.ts
+++ b/control-plane/src/modules/assets.ts
@@ -5,12 +5,16 @@ import { UPLOAD_BUCKET, getPresignedURL } from "./s3";
 
 export type AssetType = "client_library" | "service_bundle";
 
-export const createAssetUploadWithTarget = async (
-  target: string,
-  clusterId: string,
-  type: AssetType,
-): Promise<string | null> => {
-  const id = ulid();
+export const createAssetUploadWithTarget = async ({
+  target,
+  clusterId,
+  type,
+}: {
+  target: string;
+  clusterId: string;
+  type: AssetType;
+}): Promise<string> => {
+  const id = target;
   const key = `${type}/${id}`;
   if (!UPLOAD_BUCKET) {
     throw new Error("Upload bucket not configured");
@@ -32,38 +36,38 @@ export const createAssetUploadWithTarget = async (
         );
 
       if (version.length == 0) {
-        console.warn("Could not find client version for target", {
-          target,
-          clusterId,
-        });
-        return null;
+        throw new Error(`Could not find client version for target ${target}`);
       }
 
-      await data.db.transaction(async (tx) => {
-        await tx
-          .insert(data.assetUploads)
-          .values({
-            id,
-            type: type,
-            bucket: bucket,
-            key: key,
-          })
-          .returning({
-            id: data.assetUploads.id,
-          });
+      try {
+        await data.db.transaction(async (tx) => {
+          await tx
+            .insert(data.assetUploads)
+            .values({
+              id,
+              type: type,
+              bucket: bucket,
+              key: key,
+            })
+            .returning({
+              id: data.assetUploads.id,
+            });
 
-        await tx
-          .update(data.clientLibraryVersions)
-          .set({
-            asset_upload_id: id,
-          })
-          .where(
-            and(
-              eq(data.clientLibraryVersions.cluster_id, clusterId),
-              eq(data.clientLibraryVersions.id, target),
-            ),
-          );
-      });
+          await tx
+            .update(data.clientLibraryVersions)
+            .set({
+              asset_upload_id: id,
+            })
+            .where(
+              and(
+                eq(data.clientLibraryVersions.cluster_id, clusterId),
+                eq(data.clientLibraryVersions.id, target),
+              ),
+            );
+        });
+      } catch (e) {
+        throw new Error(`Could not create asset upload for target ${target}`);
+      }
       break;
     }
     case "service_bundle": {
@@ -80,40 +84,37 @@ export const createAssetUploadWithTarget = async (
         );
 
       if (deployment.length == 0) {
-        console.warn("Could not find deployment for target", {
-          target,
-          clusterId,
-        });
-        return null;
+        throw new Error(`Could not find deployment for target ${target}`);
       }
 
-      await data.db.transaction(async (tx) => {
-        await tx
-          .insert(data.assetUploads)
-          .values({
-            id,
-            type: type,
-            bucket: bucket,
-            key: key,
-          })
-          .returning({
-            id: data.assetUploads.id,
-          });
+      try {
+        await data.db.transaction(async (tx) => {
+          await tx
+            .insert(data.assetUploads)
+            .values({
+              id,
+              type: type,
+              bucket: bucket,
+              key: key,
+            })
+            .returning({
+              id: data.assetUploads.id,
+            });
 
-        await tx
-          .update(data.deployments)
-          .set({
-            asset_upload_id: id,
-          })
-          .where(eq(data.deployments.id, target));
-      });
+          await tx
+            .update(data.deployments)
+            .set({
+              asset_upload_id: id,
+            })
+            .where(eq(data.deployments.id, target));
+        });
+      } catch (e) {
+        throw new Error(`Could not create asset upload for target ${target}`);
+      }
       break;
     }
     default: {
-      console.warn("Invalid asset type provided", {
-        type,
-      });
-      return null;
+      throw new Error(`Unknown asset type ${type}`);
     }
   }
 

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -414,9 +414,8 @@ export const definition = {
     responses: {
       501: z.undefined(),
       401: z.undefined(),
-      200: z.object({
+      201: z.object({
         id: z.string(),
-        packageUploadUrl: z.string(),
         status: z.string(),
       }),
     },
@@ -474,7 +473,7 @@ export const definition = {
       }),
     },
   },
-  createClientLibrary: {
+  createClientLibraryVersion: {
     method: "POST",
     path: "/clusters/:clusterId/client-libraries",
     headers: z.object({
@@ -484,10 +483,28 @@ export const definition = {
     responses: {
       501: z.undefined(),
       401: z.undefined(),
-      200: z.object({
+      201: z.object({
         id: z.string(),
-        packageUploadUrl: z.string(),
+        version: z.string(),
       }),
+    },
+  },
+  createAsset: {
+    method: "POST",
+    path: "/clusters/:clusterId/assets",
+    headers: z.object({
+      authorization: z.string(),
+    }),
+    body: z.object({
+      type: z.enum(["client_library", "service_bundle"]),
+      target: z.string(),
+    }),
+    responses: {
+      201: z.object({
+        presignedUrl: z.string(),
+      }),
+      400: z.undefined(),
+      401: z.undefined(),
     },
   },
   setClusterSettings: {

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -189,9 +189,9 @@ export const deployments = pgTable("deployments", {
   })
     .defaultNow()
     .notNull(),
-  asset_upload_id: varchar("asset_upload_id", { length: 1024 })
-    .references(() => assetUploads.id)
-    .notNull(),
+  asset_upload_id: varchar("asset_upload_id", { length: 1024 }).references(
+    () => assetUploads.id,
+  ),
   meta: json("meta"),
   status: text("status", {
     enum: ["uploading", "ready", "active", "inactive"],
@@ -202,6 +202,28 @@ export const deployments = pgTable("deployments", {
     enum: ["lambda", "mock"],
   }).notNull(),
 });
+
+export const clientLibraryVersions = pgTable(
+  "client_library_versions",
+  {
+    id: varchar("id", { length: 1024 }).notNull(),
+    cluster_id: varchar("cluster_id")
+      .references(() => clusters.id)
+      .notNull(),
+    version: varchar("version", { length: 1024 }).notNull(),
+    asset_upload_id: varchar("asset_upload_id", { length: 1024 }).references(
+      () => assetUploads.id,
+    ),
+  },
+  (table) => ({
+    pk: primaryKey(table.cluster_id, table.id),
+    unique: {
+      uniqueVersion: {
+        columns: [table.cluster_id, table.version],
+      },
+    },
+  }),
+);
 
 export const assetUploads = pgTable("asset_uploads", {
   id: varchar("id", { length: 1024 }).primaryKey().notNull(),

--- a/control-plane/src/modules/deployment/deployment.test.ts
+++ b/control-plane/src/modules/deployment/deployment.test.ts
@@ -5,15 +5,9 @@ import {
   getDeployment,
   releaseDeployment,
 } from "./deployment";
-import { getPresignedURL } from "../s3";
 import { DeploymentProvider } from "./deployment-provider";
 import * as data from "../data";
 import { eq } from "drizzle-orm";
-
-jest.mock("../s3", () => ({
-  UPLOAD_BUCKET: "mockedBucket",
-  getPresignedURL: jest.fn().mockResolvedValue("mockedPresignedURL"),
-}));
 
 describe("createDeployment", () => {
   let owner: { clusterId: string };
@@ -34,22 +28,6 @@ describe("createDeployment", () => {
 
     expect(result.id).toBeDefined();
     expect(result.clusterId).toEqual(owner.clusterId);
-  });
-
-  it("should generate a presigned url", async () => {
-    const result = await createDeployment({
-      clusterId: owner.clusterId,
-      serviceName: "testService",
-    });
-
-    expect(result.id).toBeDefined();
-    expect(result.clusterId).toEqual(owner.clusterId);
-
-    expect(getPresignedURL).toHaveBeenCalledTimes(1);
-    expect(getPresignedURL).toHaveBeenCalledWith(
-      "mockedBucket",
-      `${owner.clusterId}/testService/service_bundle/${result.id}`,
-    );
   });
 });
 

--- a/control-plane/src/modules/deployment/deployment.test.ts
+++ b/control-plane/src/modules/deployment/deployment.test.ts
@@ -1,6 +1,5 @@
 import { createOwner } from "../test/util";
 import {
-  Deployment,
   createDeployment,
   getDeployment,
   releaseDeployment,

--- a/control-plane/src/modules/deployment/deployment.ts
+++ b/control-plane/src/modules/deployment/deployment.ts
@@ -12,11 +12,7 @@ export type Deployment = {
   service: string;
   status: string;
   provider: string;
-  assetUploadId: string;
-};
-
-export type DeploymentWithUploadUrl = Deployment & {
-  packageUploadUrl: string;
+  assetUploadId?: string | null;
 };
 
 export const s3AssetDetails = async (
@@ -24,6 +20,10 @@ export const s3AssetDetails = async (
 ): Promise<{ S3Bucket: string; S3Key: string }> => {
   if (!UPLOAD_BUCKET) {
     throw new Error("Upload bucket not configured");
+  }
+
+  if (!deployment.assetUploadId) {
+    throw new Error("Deployment does not have an asset upload");
   }
 
   const asset = await data.db
@@ -46,22 +46,10 @@ export const createDeployment = async ({
 }: {
   clusterId: string;
   serviceName: string;
-}): Promise<DeploymentWithUploadUrl> => {
+}): Promise<Deployment> => {
   if (!UPLOAD_BUCKET) {
     throw new Error("Upload bucket not configured");
   }
-
-  const id = ulid();
-
-  const deploymentAsset = {
-    bucket: UPLOAD_BUCKET,
-    key: `${clusterId}/${serviceName}/service_bundle/${id}`,
-  };
-
-  const packageUploadUrl = await getPresignedURL(
-    deploymentAsset.bucket,
-    deploymentAsset.key,
-  );
 
   const service = (
     await data.db
@@ -82,45 +70,27 @@ export const createDeployment = async ({
 
   const provider = service?.deployment_provider ?? "mock";
 
-  return await data.db.transaction(async (tx) => {
-    const asset = await tx
-      .insert(data.assetUploads)
-      .values([
-        {
-          id: ulid(),
-          type: "service_bundle",
-          bucket: deploymentAsset.bucket,
-          key: deploymentAsset.key,
-        },
-      ])
-      .returning({
-        id: data.assetUploads.id,
-      });
+  const deployment = await data.db
+    .insert(data.deployments)
+    .values([
+      {
+        id: ulid(),
+        cluster_id: clusterId,
+        service: serviceName,
+        // Temporary, the expectation is that the deployment will be in the "uploading" while any async work is being done
+        status: "ready",
+        provider: provider,
+      },
+    ])
+    .returning({
+      id: data.deployments.id,
+      clusterId: data.deployments.cluster_id,
+      service: data.deployments.service,
+      status: data.deployments.status,
+      provider: data.deployments.provider,
+    });
 
-    const deployment = await tx
-      .insert(data.deployments)
-      .values([
-        {
-          id: id,
-          cluster_id: clusterId,
-          service: serviceName,
-          asset_upload_id: asset[0].id,
-          // Temporary, the expectation is that the deployment will be in the "uploading" while any async work is being done
-          status: "ready",
-          provider: provider,
-        },
-      ])
-      .returning({
-        id: data.deployments.id,
-        clusterId: data.deployments.cluster_id,
-        service: data.deployments.service,
-        status: data.deployments.status,
-        provider: data.deployments.provider,
-        assetUploadId: data.deployments.asset_upload_id,
-      });
-
-    return { ...deployment[0], packageUploadUrl: packageUploadUrl };
-  });
+  return deployment[0];
 };
 
 export const getDeployment = async (id: string): Promise<Deployment> => {

--- a/control-plane/src/modules/deployment/deployment.ts
+++ b/control-plane/src/modules/deployment/deployment.ts
@@ -1,6 +1,5 @@
 import { ulid } from "ulid";
 import * as data from "../data";
-import { UPLOAD_BUCKET, getPresignedURL } from "../s3";
 import { and, eq, or, sql } from "drizzle-orm";
 import { DeploymentProvider } from "./deployment-provider";
 import NodeCache from "node-cache";
@@ -18,10 +17,6 @@ export type Deployment = {
 export const s3AssetDetails = async (
   deployment: Deployment,
 ): Promise<{ S3Bucket: string; S3Key: string }> => {
-  if (!UPLOAD_BUCKET) {
-    throw new Error("Upload bucket not configured");
-  }
-
   if (!deployment.assetUploadId) {
     throw new Error("Deployment does not have an asset upload");
   }
@@ -47,10 +42,6 @@ export const createDeployment = async ({
   clusterId: string;
   serviceName: string;
 }): Promise<Deployment> => {
-  if (!UPLOAD_BUCKET) {
-    throw new Error("Upload bucket not configured");
-  }
-
   const service = (
     await data.db
       .select({ deployment_provider: data.services.deployment_provider })

--- a/control-plane/src/modules/deployment/deployment.ts
+++ b/control-plane/src/modules/deployment/deployment.ts
@@ -101,7 +101,6 @@ export const getDeployment = async (id: string): Promise<Deployment> => {
       service: data.deployments.service,
       status: data.deployments.status,
       provider: data.deployments.provider,
-      assetUploadId: data.deployments.asset_upload_id,
     })
     .from(data.deployments)
     .where(eq(data.deployments.id, id));

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -21,6 +21,8 @@ import * as events from "./observability/events";
 import * as routingHelpers from "./routing-helpers";
 import { UPLOAD_BUCKET, getPresignedURL } from "./s3";
 import { ulid } from "ulid";
+import { and, eq } from "drizzle-orm";
+import { createAssetUploadWithTarget } from "./assets";
 
 const readFile = util.promisify(fs.readFile);
 
@@ -402,7 +404,7 @@ export const router = s.router(contract, {
     });
 
     return {
-      status: 200,
+      status: 201,
       body: deployment,
     };
   },
@@ -536,7 +538,7 @@ export const router = s.router(contract, {
       body: result,
     };
   },
-  createClientLibrary: async (request) => {
+  createClientLibraryVersion: async (request) => {
     const access = await routingHelpers.validateManagementAccess(request);
     if (!access) {
       return {
@@ -545,42 +547,56 @@ export const router = s.router(contract, {
     }
 
     const { clusterId } = request.params;
-
-    if (UPLOAD_BUCKET === undefined) {
-      return {
-        status: 501,
-      };
-    }
-
-    const id = ulid();
-    const libraryAsset = {
-      bucket: UPLOAD_BUCKET,
-      key: `${clusterId}/client_library/${id}`,
-    };
-
-    const clientUploadPath = await getPresignedURL(
-      libraryAsset.bucket,
-      libraryAsset.key,
-    );
-
-    await data.db
-      .insert(data.assetUploads)
+    const client = await data.db
+      .insert(data.clientLibraryVersions)
       .values({
-        id,
-        type: "client_library",
-        bucket: libraryAsset.bucket,
-        key: libraryAsset.key,
+        id: ulid(),
+        cluster_id: clusterId,
+        version: "1.0.0",
       })
       .returning({
-        id: data.assetUploads.id,
+        id: data.clientLibraryVersions.id,
+        version: data.clientLibraryVersions.version,
       });
 
     return {
-      status: 200,
-      body: {
-        id,
-        packageUploadUrl: clientUploadPath,
-      },
+      status: 201,
+      body: client[0],
     };
+  },
+  createAsset: async (request) => {
+    const access = await routingHelpers.validateManagementAccess(request);
+    if (!access) {
+      return {
+        status: 401,
+      };
+    }
+
+    const { clusterId } = request.params;
+    const { type, target } = request.body;
+
+    try {
+      const presignedUrl = await createAssetUploadWithTarget(
+        target,
+        clusterId,
+        type,
+      );
+      if (!presignedUrl) {
+        return {
+          status: 400,
+        };
+      }
+      return {
+        status: 201,
+        body: {
+          presignedUrl: presignedUrl,
+        },
+      };
+    } catch (e) {
+      console.error(e);
+      return {
+        status: 400,
+      };
+    }
   },
 });

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -576,11 +576,11 @@ export const router = s.router(contract, {
     const { type, target } = request.body;
 
     try {
-      const presignedUrl = await createAssetUploadWithTarget(
+      const presignedUrl = await createAssetUploadWithTarget({
         target,
         clusterId,
         type,
-      );
+      });
       if (!presignedUrl) {
         return {
           status: 400,


### PR DESCRIPTION
Refactors the asset upload behaviour to be common between client library and service bundle uploads.

A new endpoint, `createAsset` been introduced which accepts a `target` (either a `deployment` or `client_library_versions`) and will return a pre-signed S3 URL for uploading an asset.
The CLI can now share the same upload behaviour _regardless_ of the target type, making it easier to introduce additional uploads in the future.

Also:
- Creates a new table `client_library_versions` to track client version uploads.
- The CLI `client publish` command now provides the option to upload a client library to `npm`
