### PR TITLE
chore: Use pull_request_target to build PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
 
 jobs:
   default:


### PR DESCRIPTION
Add `pull_request_target` which allows access to secrets for incoming PRs.