### PR TITLE
feat: Inject API secret into deployments

### DIFF
--- a/control-plane/src/modules/cluster.ts
+++ b/control-plane/src/modules/cluster.ts
@@ -35,3 +35,19 @@ export const operationalCluster = async (
 
   return results[0];
 };
+
+export const getCluster = async (clusterId: string) => {
+  const [cluster] = await data.db
+    .select({
+      id: data.clusters.id,
+      apiSecret: data.clusters.api_secret,
+    })
+    .from(data.clusters)
+    .where(eq(data.clusters.id, clusterId));
+
+  if (!cluster) {
+    throw new Error(`Cluster not found: ${clusterId}`);
+  }
+
+  return cluster;
+};

--- a/control-plane/src/modules/deployment/deployment.test.ts
+++ b/control-plane/src/modules/deployment/deployment.test.ts
@@ -115,20 +115,18 @@ describe("releaseDeployment", () => {
       serviceName: "testService",
     });
 
-    delete (deployment as any).packageUploadUrl;
-
     await releaseDeployment(deployment, provider);
 
     expect(await getDeployment(deployment.id)).toEqual({
       ...deployment,
       status: "active",
+      assetUploadId: null,
     });
 
     const deployment2 = await createDeployment({
       clusterId: owner.clusterId,
       serviceName: "testService",
     });
-    delete (deployment2 as any).packageUploadUrl;
 
     await releaseDeployment(deployment2, provider);
 
@@ -136,10 +134,12 @@ describe("releaseDeployment", () => {
     expect(await getDeployment(deployment.id)).toEqual({
       ...deployment,
       status: "inactive",
+      assetUploadId: null,
     });
     expect(await getDeployment(deployment2.id)).toEqual({
       ...deployment2,
       status: "active",
+      assetUploadId: null,
     });
   });
 });

--- a/control-plane/src/modules/deployment/deployment.ts
+++ b/control-plane/src/modules/deployment/deployment.ts
@@ -92,6 +92,7 @@ export const getDeployment = async (id: string): Promise<Deployment> => {
       service: data.deployments.service,
       status: data.deployments.status,
       provider: data.deployments.provider,
+      assetUploadId: data.deployments.asset_upload_id,
     })
     .from(data.deployments)
     .where(eq(data.deployments.id, id));

--- a/ts-core/src/Differential.test.ts
+++ b/ts-core/src/Differential.test.ts
@@ -1,7 +1,33 @@
 import { Differential } from "./Differential";
 
 describe("Differential", () => {
+  const env = process.env;
+  beforeEach(() => {
+    delete process.env.DIFFERENTIAL_API_SECRET;
+  });
+
+  afterEach(() => {
+    process.env = { ...env };
+  });
   it("should initialize without optional args", () => {
     expect(() => new Differential("test")).not.toThrow();
+  });
+
+  it("should throw if no API secret is provided", () => {
+    expect(() => new Differential()).toThrow();
+  });
+
+  it("should initialize with API secret in environment", () => {
+    process.env.DIFFERENTIAL_API_SECRET = "test";
+    expect(() => new Differential()).not.toThrow();
+  });
+
+  it("should warn for multiple API secrets", () => {
+    process.env.DIFFERENTIAL_API_SECRET = "test";
+    jest.spyOn(console, "warn");
+    expect(() => new Differential("test")).not.toThrow();
+    expect(console.warn).toHaveBeenCalledWith(
+      "API Secret was provided as an argument and environment variable. Constructor argument will be used.",
+    );
   });
 });

--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -406,6 +406,7 @@ class PollingAgent {
  * ```
  */
 export class Differential {
+  private apiSecret: string;
   private authHeader: string;
   private endpoint: string;
   private machineId: string;
@@ -423,7 +424,7 @@ export class Differential {
 
   /**
    * Initializes a new Differential instance.
-   * @param apiSecret The API Secret for your Differential cluster. You can obtain one from https://api.differential.dev/demo/token.
+   * @param apiSecret The API Secret for your Differential cluster. If not provided, it will be read from the `DIFFERENTIAL_API_SECRET` environment variable. You can obtain one from https://api.differential.dev/demo/token.
    * @param options Additional options for the Differential client.
    * @param options.endpoint The endpoint for the Differential cluster. Defaults to https://api.differential.dev.
    * @param options.encryptionKeys An array of encryption keys to use for encrypting and decrypting data. These keys are never sent to the control-plane and allows you to encrypt function arguments and return values. If you do not provide any keys, Differential will not encrypt any data. Encryption has a performance impact on your functions. When you want to rotate keys, you can add new keys to the start of the array. Differential will try to decrypt data with each key in the array until it finds a key that works. Differential will encrypt data with the first key in the array. Each key must be 32 bytes long.
@@ -443,13 +444,20 @@ export class Differential {
    * ```
    */
   constructor(
-    private apiSecret: string,
+    apiSecret?: string,
     options?: {
       endpoint?: string;
       encryptionKeys?: Buffer[];
       jobPollWaitTime?: number;
     },
   ) {
+    apiSecret = apiSecret || process.env.DIFFERENTIAL_API_SECRET;
+    if (!apiSecret) {
+      throw new DifferentialError("No API Secret provided.");
+    }
+
+    this.apiSecret = apiSecret;
+
     this.authHeader = `Basic ${this.apiSecret}`;
     this.endpoint = options?.endpoint || "https://api.differential.dev";
     this.machineId = Math.random().toString(36).substring(7);

--- a/ts-core/src/Differential.ts
+++ b/ts-core/src/Differential.ts
@@ -451,6 +451,11 @@ export class Differential {
       jobPollWaitTime?: number;
     },
   ) {
+    if (apiSecret && process.env.DIFFERENTIAL_API_SECRET) {
+      console.warn(
+        "API Secret was provided as an argument and environment variable. Constructor argument will be used.",
+      );
+    }
     apiSecret = apiSecret || process.env.DIFFERENTIAL_API_SECRET;
     if (!apiSecret) {
       throw new DifferentialError("No API Secret provided.");


### PR DESCRIPTION
- Inject API Secret into Lambda deployments.
- Update `Differential` to fallback to `process.env.DIFFERENTIAL_API_SECRET`