### PR TITLE
feat: Update CloudFormation deployments based on SNS

### DIFF
--- a/cli/src/commands/client-lib-publish.ts
+++ b/cli/src/commands/client-lib-publish.ts
@@ -92,6 +92,7 @@ export const ClientLibraryPublish: CommandModule<{}, ClientLibraryPublishArgs> =
         });
 
         if (libraryResponse.status !== 201) {
+          log("Failed to create library version", { libraryResponse });
           throw new Error(
             `Failed to create client library: ${libraryResponse.status}`,
           );

--- a/cli/src/lib/client.ts
+++ b/cli/src/lib/client.ts
@@ -16,9 +16,9 @@ export const waitForDeploymentStatus = async (
   deploymentId: string,
   serviceName: string,
   clusterId: string,
-  target: string,
+  targets: string[],
   maxAttempts: number = 10,
-) => {
+): Promise<string> => {
   const checkDeployment = () =>
     client.getDeployment({
       params: {
@@ -33,8 +33,8 @@ export const waitForDeploymentStatus = async (
     attempts++;
     const result = await checkDeployment();
 
-    if (result.status == 200 && result.body.status === target) {
-      return;
+    if (result.status == 200 && targets.includes(result.body.status)) {
+      return result.body.status;
     }
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }

--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -17,6 +17,7 @@
     "@aws-sdk/client-cloudformation": "^3.529.1",
     "@aws-sdk/client-lambda": "^3.504.0",
     "@aws-sdk/client-s3": "^3.496.0",
+    "@aws-sdk/client-sns": "^3.529.1",
     "@aws-sdk/s3-request-presigner": "^3.496.0",
     "@babel/preset-env": "^7.22.10",
     "@babel/preset-typescript": "^7.22.11",
@@ -42,6 +43,7 @@
     "pg": "^8.11.2",
     "prom-client": "^15.1.0",
     "semver": "^7.6.0",
+    "sns-validator": "^0.3.5",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",
     "ulid": "^2.3.0",
@@ -50,6 +52,7 @@
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.2",
     "@types/pg": "^8.10.2",
+    "@types/sns-validator": "^0.3.3",
     "@types/ws": "^8.5.5",
     "tsx": "^4.7.0"
   },

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -437,7 +437,13 @@ export const definition = {
       404: z.undefined(),
       200: z.object({
         id: z.string(),
-        status: z.string(),
+        status: z.enum([
+          "uploading",
+          "active",
+          "inactive",
+          "failed",
+          "cancelled",
+        ]),
         clusterId: z.string(),
         service: z.string(),
         provider: z.string(),
@@ -452,14 +458,22 @@ export const definition = {
       authorization: z.string(),
     }),
     query: z.object({
-      status: z.enum(["uploading", "ready", "active", "inactive"]).optional(),
+      status: z
+        .enum(["uploading", "active", "inactive", "failed", "cancelled"])
+        .optional(),
       limit: z.coerce.number().min(1).max(100).default(10),
     }),
     responses: {
       200: z.array(
         z.object({
           id: z.string(),
-          status: z.string(),
+          status: z.enum([
+            "uploading",
+            "active",
+            "inactive",
+            "failed",
+            "cancelled",
+          ]),
           clusterId: z.string(),
           service: z.string(),
           provider: z.string(),
@@ -610,6 +624,21 @@ export const definition = {
       501: z.undefined(),
       404: z.undefined(),
       200: z.any(),
+    },
+  },
+  sns: {
+    method: "POST",
+    body: z.object({
+      Token: z.string().optional(),
+      Message: z.string().optional(),
+      TopicArn: z.string(),
+      Subject: z.string().optional(),
+      Type: z.enum(["Notification", "SubscriptionConfirmation"]),
+    }),
+    path: "/events/sns",
+    responses: {
+      200: z.undefined(),
+      400: z.undefined(),
     },
   },
 } as const;

--- a/control-plane/src/modules/deployment/cfn-manager.test.ts
+++ b/control-plane/src/modules/deployment/cfn-manager.test.ts
@@ -1,0 +1,50 @@
+import { deploymentResultFromNotification } from "./cfn-manager";
+
+describe("deploymentResultFromNotification", () => {
+  const stackId = "arn:aws:cloudformation:xxxx";
+  const clientRequestToken = "xxxx";
+  it("throws if status is missing", () => {
+    expect(() => deploymentResultFromNotification({})).toThrow();
+  });
+
+  it.each(["CREATE_COMPLETE", "UPDATE_COMPLETE"])(
+    "%s status is treated as a success",
+    (status) => {
+      const result = deploymentResultFromNotification({
+        ResourceStatus: status,
+        ResourceStatusReason: "",
+        ClientRequestToken: clientRequestToken,
+        StackId: stackId,
+      });
+      expect(result).toMatchObject({
+        success: true,
+        pending: false,
+        status,
+        stackId,
+        clientRequestToken,
+      });
+    },
+  );
+
+  it.each([
+    "UPDATE_ROLLBACK_FAILED",
+    "ROLLBACK_FAILED",
+    "UPDATE_ROLLBACK_COMPLETE",
+    "DELETE_COMPLETE",
+  ])("%s status is treated as a failure", (status) => {
+    const result = deploymentResultFromNotification({
+      ResourceStatus: status,
+      ResourceStatusReason: "Something went wrong!",
+      ClientRequestToken: clientRequestToken,
+      StackId: stackId,
+    });
+    expect(result).toMatchObject({
+      success: false,
+      pending: false,
+      reason: "Something went wrong!",
+      status,
+      stackId,
+      clientRequestToken,
+    });
+  });
+});

--- a/control-plane/src/modules/deployment/deployment-provider.ts
+++ b/control-plane/src/modules/deployment/deployment-provider.ts
@@ -8,8 +8,6 @@ import { LambdaCfnProvider } from "./lambda-cfn-provider";
 const mockProvider = new MockProvider();
 const lambdaProvider = new LambdaCfnProvider();
 
-lambdaProvider.startPollingDeployments();
-
 export const getDeploymentProvider = (provider: string): DeploymentProvider => {
   switch (provider) {
     case "lambda":

--- a/control-plane/src/modules/deployment/deployment.ts
+++ b/control-plane/src/modules/deployment/deployment.ts
@@ -9,7 +9,7 @@ export type Deployment = {
   id: string;
   clusterId: string;
   service: string;
-  status: string;
+  status: "uploading" | "active" | "inactive" | "failed" | "cancelled";
   provider: string;
   assetUploadId?: string | null;
   createdAt: Date;
@@ -163,7 +163,7 @@ export const releaseDeployment = async (
     update = await tx
       .update(data.deployments)
       .set({
-        meta: meta,
+        meta: meta ?? {},
       })
       .where(eq(data.deployments.id, deployment.id))
       .returning({
@@ -243,8 +243,8 @@ export const getAllPendingDeployments = async (
 };
 
 export const updateDeploymentResult = async (
-  deployment: Deployment,
-  status: "active" | "failed",
+  deployment: { id: string },
+  status: "active" | "failed" | "uploading",
   meta?: any,
 ) => {
   await data.db

--- a/control-plane/src/modules/sns.test.ts
+++ b/control-plane/src/modules/sns.test.ts
@@ -1,0 +1,17 @@
+import { parseCloudFormationMessage } from "./sns";
+
+describe("parseCloudFormationMessages", () => {
+  const testNotification = `
+'StackId'='arn:aws:cloudformation:xxxx'
+'ResourceStatus'='UPDATE_FAILED'
+'ResourceStatusReason'='Something went wrong!'
+'ClientRequestToken'='xxxx'
+`;
+  it("parses the stackName", () => {
+    const result = parseCloudFormationMessage(testNotification);
+    expect(result.StackId).toBe("arn:aws:cloudformation:xxxx");
+    expect(result.ResourceStatus).toBe("UPDATE_FAILED");
+    expect(result.ResourceStatusReason).toBe("Something went wrong!");
+    expect(result.ClientRequestToken).toBe("xxxx");
+  });
+});

--- a/control-plane/src/modules/sns.ts
+++ b/control-plane/src/modules/sns.ts
@@ -1,0 +1,43 @@
+import { ConfirmSubscriptionCommand, SNSClient } from "@aws-sdk/client-sns";
+import MessageValidator from "sns-validator";
+
+export const DELOYMENT_SNS_TOPIC = process.env.DELOYMENT_SNS_TOPIC;
+
+const validator = new MessageValidator();
+const sns = new SNSClient();
+
+// "'stackId'='XXXX'\n";
+export const parseCloudFormationMessage = (notification: string) =>
+  notification
+    .replace(/"/g, "")
+    .replace(/'/g, "")
+    .split("\n")
+    .reduce(
+      (acc, line) => {
+        const [key, value] = line.split("=");
+        acc[key] = value;
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+
+export const confirmSubscription = async (options: {
+  Token: string;
+  TopicArn: string;
+}) => {
+  await sns.send(new ConfirmSubscriptionCommand(options));
+};
+
+export const validateSignature = async (
+  message: Record<string, unknown>,
+): Promise<boolean> => {
+  return new Promise((resolve, reject) =>
+    validator.validate(message, (err: any) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(true);
+      }
+    }),
+  );
+};

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -18,7 +18,10 @@ The stack can be provisioned by running the following command in your shell:
 aws cloudformation create-stack \
     --stack-name $STACK_NAME \
     --template-body file://cfn.yaml \
-    --parameters ParameterKey=AssetUploadBucketName,ParameterValue=${ASSET_BUCKET_NAME} \
+    --parameters \
+    ParameterKey=AssetUploadBucketName,ParameterValue=${ASSET_BUCKET_NAME} \
+    ParameterKey=CfnTemplateBucketName,ParameterValue=${CFN_BUCKET_NAME} \
+    ParameterKey=CfnSNSWebhook,ParameterValue=${CFN_WEBHOOK} \
     --capabilities CAPABILITY_NAMED_IAM CAPABILITY_IAM
 ```
 
@@ -31,5 +34,7 @@ aws cloudformation update-stack \
     --stack-name $STACK_NAME \
     --template-body file://cfn.yaml \
     --parameters ParameterKey=AssetUploadBucketName,ParameterValue=${ASSET_BUCKET_NAME} \
+    ParameterKey=CfnTemplateBucketName,ParameterValue=${CFN_BUCKET_NAME} \
+    ParameterKey=CloudFormationWebhook,ParameterValue=${CFN_WEBHOOK} \
     --capabilities CAPABILITY_NAMED_IAM CAPABILITY_IAM
 ```

--- a/infrastructure/cfn.yaml
+++ b/infrastructure/cfn.yaml
@@ -8,6 +8,10 @@ Parameters:
     Type: String
     Description: Name for the S3 bucket used for CFN template storage
 
+  CfnSNSWebhook:
+    Type: String
+    Description: URL of the control plane CF webhook
+
 Resources:
   AssetUploadBucket:
     Type: AWS::S3::Bucket
@@ -57,6 +61,24 @@ Resources:
               Resource: !GetAtt DeploymentLambdaRuntimeRole.Arn
         Users:
           - !Ref ControlPlaneUser
+
+  DeploymentCloudFormationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: DeploymentCloudFormationTopic
+
+  DeploymentCloudFormationSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Ref CfnSNSWebhook
+      TopicArn: !Ref DeploymentCloudFormationTopic
+      Protocol: "https"
+      DeliveryPolicy: |
+        {
+          "requestPolicy": {
+            "headerContentType": "application/json; charset=UTF-8"
+          }
+        }
 
   DeploymentLambdaRuntimeRole:
     Type: AWS::IAM::Role

--- a/infrastructure/deployment/lambda-cfn.yaml
+++ b/infrastructure/deployment/lambda-cfn.yaml
@@ -92,6 +92,7 @@ Resources:
 
   DifferentialServiceInvokeConfig:
     Type: AWS::Lambda::EventInvokeConfig
+    DependsOn: DifferentialService
     Properties:
       FunctionName: !Ref FunctionName
       Qualifier: "$LATEST"

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,7 @@
         "@aws-sdk/client-cloudformation": "^3.529.1",
         "@aws-sdk/client-lambda": "^3.504.0",
         "@aws-sdk/client-s3": "^3.496.0",
+        "@aws-sdk/client-sns": "^3.529.1",
         "@aws-sdk/s3-request-presigner": "^3.496.0",
         "@babel/preset-env": "^7.22.10",
         "@babel/preset-typescript": "^7.22.11",
@@ -130,6 +131,7 @@
         "pg": "^8.11.2",
         "prom-client": "^15.1.0",
         "semver": "^7.6.0",
+        "sns-validator": "^0.3.5",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6",
         "ulid": "^2.3.0",
@@ -138,6 +140,7 @@
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.2",
         "@types/pg": "^8.10.2",
+        "@types/sns-validator": "^0.3.3",
         "@types/ws": "^8.5.5",
         "tsx": "^4.7.0"
       }
@@ -1348,6 +1351,494 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.529.1.tgz",
+      "integrity": "sha512-Tx6R+O5JMeqINYezFZZgDamH6Am2zIkjuPAoRX2JMThZqb6RKIFuAda+jCOe9lSlr0qH97hYPZJAeJUwEhd1VQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.529.1",
+        "@aws-sdk/core": "3.529.1",
+        "@aws-sdk/credential-provider-node": "3.529.1",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.525.0",
+        "@aws-sdk/region-config-resolver": "3.525.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.525.0",
+        "@smithy/config-resolver": "^2.1.4",
+        "@smithy/core": "^1.3.5",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-retry": "^2.1.4",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.4",
+        "@smithy/util-defaults-mode-node": "^2.2.3",
+        "@smithy/util-endpoints": "^1.1.4",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.529.1.tgz",
+      "integrity": "sha512-KT1U/ZNjDhVv2ZgjzaeAn9VM7l667yeSguMrRYC8qk5h91/61MbjZypi6eOuKuVM+0fsQvzKScTQz0Lio0eYag==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.529.1",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.525.0",
+        "@aws-sdk/region-config-resolver": "3.525.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.525.0",
+        "@smithy/config-resolver": "^2.1.4",
+        "@smithy/core": "^1.3.5",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-retry": "^2.1.4",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.4",
+        "@smithy/util-defaults-mode-node": "^2.2.3",
+        "@smithy/util-endpoints": "^1.1.4",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.529.1.tgz",
+      "integrity": "sha512-bimxCWAvRnVcluWEQeadXvHyzWlBWsuGVligsaVZaGF0TLSn0eLpzpN9B1EhHzTf7m0Kh/wGtPSH1JxO6PpB+A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.529.1",
+        "@aws-sdk/core": "3.529.1",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.525.0",
+        "@aws-sdk/region-config-resolver": "3.525.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.525.0",
+        "@smithy/config-resolver": "^2.1.4",
+        "@smithy/core": "^1.3.5",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-retry": "^2.1.4",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.4",
+        "@smithy/util-defaults-mode-node": "^2.2.3",
+        "@smithy/util-endpoints": "^1.1.4",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.529.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sts": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.529.1.tgz",
+      "integrity": "sha512-Rvk2Sr3MACQTOtngUU+omlf4E17k47dRVXR7OFRD6Ow5iGgC9tkN2q/ExDPW/ktPOmM0lSgzWyQ6/PC/Zq3HUg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.529.1",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.525.0",
+        "@aws-sdk/region-config-resolver": "3.525.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.525.0",
+        "@smithy/config-resolver": "^2.1.4",
+        "@smithy/core": "^1.3.5",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-retry": "^2.1.4",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.4",
+        "@smithy/util-defaults-mode-node": "^2.2.3",
+        "@smithy/util-endpoints": "^1.1.4",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.529.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/core": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.529.1.tgz",
+      "integrity": "sha512-Sj42sYPfaL9PHvvciMICxhyrDZjqnnvFbPKDmQL5aFKyXy122qx7RdVqUOQERDmMQfvJh6+0W1zQlLnre89q4Q==",
+      "dependencies": {
+        "@smithy/core": "^1.3.5",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/signature-v4": "^2.1.3",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.523.0.tgz",
+      "integrity": "sha512-Y6DWdH6/OuMDoNKVzZlNeBc6f1Yjk1lYMjANKpIhMbkRCvLJw/PYZKOZa8WpXbTYdgg9XLjKybnLIb3ww3uuzA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.525.0.tgz",
+      "integrity": "sha512-RNWQGuSBQZhl3iqklOslUEfQ4br1V3DCPboMpeqFtddUWJV3m2u2extFur9/4Uy+1EHVF120IwZUKtd8dF+ibw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-stream": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.529.1.tgz",
+      "integrity": "sha512-RjHsuTvHIwXG7a/3ERexemiD3c9riKMCZQzY2/b0Gg0ButEVbBcMfERtUzWmQ0V4ufe/PEZjP68MH1gupcoF9A==",
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.529.1",
+        "@aws-sdk/credential-provider-env": "3.523.0",
+        "@aws-sdk/credential-provider-process": "3.523.0",
+        "@aws-sdk/credential-provider-sso": "3.529.1",
+        "@aws-sdk/credential-provider-web-identity": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/credential-provider-imds": "^2.2.3",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.529.1.tgz",
+      "integrity": "sha512-mvY7F3dMmk/0dZOCfl5sUI1bG0osureBjxhELGCF0KkJqhWI0hIzh8UnPkYytSg3vdc97CMv7pTcozxrdA3b0g==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.523.0",
+        "@aws-sdk/credential-provider-http": "3.525.0",
+        "@aws-sdk/credential-provider-ini": "3.529.1",
+        "@aws-sdk/credential-provider-process": "3.523.0",
+        "@aws-sdk/credential-provider-sso": "3.529.1",
+        "@aws-sdk/credential-provider-web-identity": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/credential-provider-imds": "^2.2.3",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.523.0.tgz",
+      "integrity": "sha512-f0LP9KlFmMvPWdKeUKYlZ6FkQAECUeZMmISsv6NKtvPCI9e4O4cLTeR09telwDK8P0HrgcRuZfXM7E30m8re0Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.529.1.tgz",
+      "integrity": "sha512-KFMKkaoTGDgSJG+o9Ii7AglWG5JQeF6IFw9cXLMwDdIrp3KUmRcUIqe0cjOoCqeQEDGy0VHsimHmKKJ3894i/A==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.529.1",
+        "@aws-sdk/token-providers": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.529.1.tgz",
+      "integrity": "sha512-AGuZDOKN+AttjwTjrF47WLqzeEut2YynyxjkXZhxZF/xn8i5Y51kUAUdXsXw1bgR25pAeXQIdhsrQlRa1Pm5kw==",
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.523.0.tgz",
+      "integrity": "sha512-4g3q7Ta9sdD9TMUuohBAkbx/e3I/juTqfKi7TPgP+8jxcYX72MOsgemAMHuP6CX27eyj4dpvjH+w4SIVDiDSmg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.523.0.tgz",
+      "integrity": "sha512-PeDNJNhfiaZx54LBaLTXzUaJ9LXFwDFFIksipjqjvxMafnoVcQwKbkoPUWLe5ytT4nnL1LogD3s55mERFUsnwg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.523.0.tgz",
+      "integrity": "sha512-nZ3Vt7ehfSDYnrcg/aAfjjvpdE+61B3Zk68i6/hSUIegT3IH9H1vSW67NDKVp+50hcEfzWwM2HMPXxlzuyFyrw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.525.0.tgz",
+      "integrity": "sha512-4al/6uO+t/QIYXK2OgqzDKQzzLAYJza1vWFS+S0lJ3jLNGyLB5BMU5KqWjDzevYZ4eCnz2Nn7z0FveUTNz8YdQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.525.0",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.525.0.tgz",
+      "integrity": "sha512-8kFqXk6UyKgTMi7N7QlhA6qM4pGPWbiUXqEY2RgUWngtxqNFGeM9JTexZeuavQI+qLLe09VPShPNX71fEDcM6w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/token-providers": {
+      "version": "3.529.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.529.1.tgz",
+      "integrity": "sha512-NpgMjsfpqiugbxrYGXtta914N43Mx/H0niidqv8wKMTgWQEtsJvYtOni+kuLXB+LmpjaMFNlpadooFU/bK4buA==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.529.1",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.525.0.tgz",
+      "integrity": "sha512-DIW7WWU5tIGkeeKX6NJUyrEIdWMiqjLQG3XBzaUj+ufIENwNjdAHhlD8l2vX7Yr3JZRT6yN/84wBCj7Tw1xd1g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-endpoints": "^1.1.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.523.0.tgz",
+      "integrity": "sha512-6ZRNdGHX6+HQFqTbIA5+i8RWzxFyxsZv8D3soRfpdyWIKkzhSz8IyRKXRciwKBJDaC7OX2jzGE90wxRQft27nA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/types": "^2.10.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.525.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.525.0.tgz",
+      "integrity": "sha512-88Wjt4efyUSBGcyIuh1dvoMqY1k15jpJc5A/3yi67clBQEFsu9QCodQCQPqmRjV3VRcMtBOk+jeCTiUzTY5dRQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -8421,6 +8912,12 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sns-validator": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sns-validator/-/sns-validator-0.3.3.tgz",
+      "integrity": "sha512-v/3bN5dak8aDXn7bgTGu+1oGc+PQCP0qnfzUM6gzo7FnxiW4wpppkaIptPhRhJaiDItbUDK+YA4yDQuVs5Cq1Q==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -21554,6 +22051,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/sns-validator": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/sns-validator/-/sns-validator-0.3.5.tgz",
+      "integrity": "sha512-lapYNmezLsltnt2fcQyhmYnC41mYZ7EjU7f2oR/hrhpbD/LemryclRpApwxO84gOyDIQ7MWe/h4HvkdunFzSKg=="
     },
     "node_modules/socks": {
       "version": "2.7.1",


### PR DESCRIPTION
Replace CloudFormation stack update polling with [SNS events](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html).

- Adds an `/events/sns` endpoint for ingesting SNS events and updating our deployment state
- `infrastructure/cfn.yaml` provisions an SNS topic / subscription for delivering events to the control-plane
- CloudFormation requests will now specify an SNS topic for delivering update events
- CloudFormation requests will specify a `ClientRequestToken` (the `deploymentId`) for routing events to the correct deployment

https://github.com/differentialhq/differential/assets/9162298/6fde7b2f-72d0-4943-b770-9c2b64b14265

