### PR TITLE
fix: Infer getJobStatuses return type

### DIFF
--- a/control-plane/src/modules/jobs/jobs.ts
+++ b/control-plane/src/modules/jobs/jobs.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { type InferModel, and, eq, inArray, sql } from "drizzle-orm";
 import * as cron from "../cron";
 import * as data from "../data";
 import * as events from "../observability/events";
@@ -144,9 +144,9 @@ export const getJobStatuses = async ({
   let jobs: Array<{
     id: string;
     service: string;
-    status: "pending" | "running" | "success" | "failure";
+    status: InferModel<typeof data.jobs>["status"];
     result: string | null;
-    resultType: "resolution" | "rejection" | null;
+    resultType: InferModel<typeof data.jobs>["result_type"];
   }>;
 
   do {

--- a/control-plane/src/modules/jobs/jobs.ts
+++ b/control-plane/src/modules/jobs/jobs.ts
@@ -1,4 +1,4 @@
-import { type InferModel, and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import * as cron from "../cron";
 import * as data from "../data";
 import * as events from "../observability/events";
@@ -144,9 +144,9 @@ export const getJobStatuses = async ({
   let jobs: Array<{
     id: string;
     service: string;
-    status: InferModel<typeof data.jobs>["status"];
+    status: "pending" | "running" | "success" | "failure";
     result: string | null;
-    resultType: InferModel<typeof data.jobs>["result_type"];
+    resultType: "resolution" | "rejection" | null;
   }>;
 
   do {

--- a/control-plane/src/modules/jobs/jobs.ts
+++ b/control-plane/src/modules/jobs/jobs.ts
@@ -1,4 +1,4 @@
-import { InferModel, and, eq, inArray, sql } from "drizzle-orm";
+import { type InferModel, and, eq, inArray, sql } from "drizzle-orm";
 import * as cron from "../cron";
 import * as data from "../data";
 import * as events from "../observability/events";
@@ -32,10 +32,10 @@ export const nextJobs = async ({
   const end = jobDurations.startTimer({ operation: "nextJobs" });
 
   const results = await data.db.execute(
-    sql`UPDATE 
-      jobs SET status = 'running', 
-      remaining_attempts = remaining_attempts - 1, 
-      last_retrieved_at=${new Date().toISOString()}, 
+    sql`UPDATE
+      jobs SET status = 'running',
+      remaining_attempts = remaining_attempts - 1,
+      last_retrieved_at=${new Date().toISOString()},
       executing_machine_id=${machineId}
     WHERE
       id IN (SELECT id FROM jobs WHERE (status = 'pending' OR (status = 'failure' AND remaining_attempts > 0))

--- a/control-plane/src/modules/jobs/jobs.ts
+++ b/control-plane/src/modules/jobs/jobs.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { InferModel, and, eq, inArray, sql } from "drizzle-orm";
 import * as cron from "../cron";
 import * as data from "../data";
 import * as events from "../observability/events";
@@ -144,9 +144,9 @@ export const getJobStatuses = async ({
   let jobs: Array<{
     id: string;
     service: string;
-    status: string;
+    status: InferModel<typeof data.jobs>["status"];
     result: string | null;
-    resultType: string | null;
+    resultType: InferModel<typeof data.jobs>["result_type"];
   }>;
 
   do {


### PR DESCRIPTION
The build started failing as `getJobStatuses` was returning `string` for `status` and `result_type` which did not confirm to the ts-rest contract.

Update the return type information.