### PR TITLE
feat: Add FORCE_POLL_DELAY to ResultsPoller

### DIFF
--- a/ts-core/src/tests/monolith/monolith.test.ts
+++ b/ts-core/src/tests/monolith/monolith.test.ts
@@ -67,7 +67,7 @@ describe("monolith", () => {
   "Expert says: foobar",
 ]
 `);
-  }, 50000);
+  });
 
   it("should not let an already started service start again", async () => {
     await expect(expertService.start()).rejects.toThrowError(


### PR DESCRIPTION
`ResultsPoller` can be blocked waiting for a slow job to resolve.

This is particularly the case in the service to service test which is currently taking ~25 seconds.

When adding a new job to `ResultsPoller`, check that the job has been attempted after `FORCE_POLL_DELAY` and trigger a forced poll if not.

My testing locally sees the problematic test time reduce from 25s -> 5s.