### PR TITLE
feat: Wrap requests in logger context

### DIFF
--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -10,7 +10,7 @@ import * as deploymentScheduler from "./modules/deployment/scheduler";
 import * as jobs from "./modules/jobs/jobs";
 import * as events from "./modules/observability/events";
 import * as router from "./modules/router";
-import { logger } from "./utilities/logger";
+import { logContext, logger } from "./utilities/logger";
 
 export const httpDurations = new Summary({
   name: "differential_http_operations_duration_ms",
@@ -48,6 +48,18 @@ app.setErrorHandler((error, request, reply) => {
   });
 
   return reply.status(500).send();
+});
+
+app.addHook("onRequest", (request, _reply, done) => {
+  const context = {
+    request: {
+      id: request.id,
+      path: request.routerPath,
+      method: request.method,
+    },
+  };
+
+  logContext.run(context, done);
 });
 
 app.addHook("onResponse", (request, reply, done) => {

--- a/control-plane/src/utilities/logger.ts
+++ b/control-plane/src/utilities/logger.ts
@@ -2,14 +2,14 @@ import { createLogger, format, transports } from "winston";
 import { AsyncLocalStorage } from "async_hooks";
 import { env } from "../utilities/env";
 
-const logContext = new AsyncLocalStorage();
+export const logContext = new AsyncLocalStorage();
 
 const winston = createLogger({
   level: env.LOG_LEVEL,
   format:
     env.NODE_ENV === "development"
       ? format.combine(format.colorize(), format.simple())
-      : format.json(),
+      : format.simple(),
   transports: [new transports.Console()],
 });
 


### PR DESCRIPTION
- Wraps requests in logger context with `path` and `requestId`
- Use `simple` log formatting in production