### PR TITLE
fix: Refactor control-plane for accepting call config (1/2)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,3 @@
 {
   "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": "explicit"
-  }
 }

--- a/admin/client/contract.ts
+++ b/admin/client/contract.ts
@@ -63,7 +63,6 @@ export const definition = {
     body: z.object({
       targetFn: z.string(),
       targetArgs: z.string(),
-      pool: z.string().optional(),
       service: z.string().default("unknown"),
       cacheKey: z.string().optional(),
     }),
@@ -222,7 +221,6 @@ export const definition = {
           z.object({
             id: z.string(),
             description: z.string().nullable(),
-            pool: z.string().nullable(),
             lastPingAt: z.date().nullable(),
             ip: z.string().nullable(),
             deploymentId: z.string().nullable(),

--- a/cli/src/client/contract.ts
+++ b/cli/src/client/contract.ts
@@ -63,7 +63,6 @@ export const definition = {
     body: z.object({
       targetFn: z.string(),
       targetArgs: z.string(),
-      pool: z.string().optional(),
       service: z.string().default("unknown"),
       cacheKey: z.string().optional(),
     }),
@@ -222,7 +221,6 @@ export const definition = {
           z.object({
             id: z.string(),
             description: z.string().nullable(),
-            pool: z.string().nullable(),
             lastPingAt: z.date().nullable(),
             ip: z.string().nullable(),
           }),

--- a/control-plane/src/modules/admin.ts
+++ b/control-plane/src/modules/admin.ts
@@ -112,7 +112,6 @@ export const getClusterDetails = async ({
     .select({
       id: data.machines.id,
       description: data.machines.description,
-      pool: data.machines.machine_type,
       lastPingAt: data.machines.last_ping_at,
       ip: data.machines.ip,
       organizationId: data.machines.cluster_id,

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -239,7 +239,6 @@ export const definition = {
           z.object({
             id: z.string(),
             description: z.string().nullable(),
-            pool: z.string().nullable(),
             lastPingAt: z.date().nullable(),
             ip: z.string().nullable(),
             deploymentId: z.string().nullable(),

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -63,9 +63,26 @@ export const definition = {
     body: z.object({
       targetFn: z.string(),
       targetArgs: z.string(),
-      pool: z.string().optional(),
-      service: z.string().default("unknown"),
-      cacheKey: z.string().optional(),
+      service: z.string(),
+      callConfig: z
+        .object({
+          cache: z
+            .object({
+              key: z.string(),
+              ttlSeconds: z.number(),
+            })
+            .optional(),
+          retry: z
+            .object({
+              attempts: z.number().min(1).max(100),
+              predictive: z.boolean().default(false),
+            })
+            .optional(),
+          timeoutSeconds: z.number().default(300),
+          executionId: z.string().optional(),
+          background: z.boolean().default(false),
+        })
+        .optional(),
     }),
   },
   getJobStatus: {

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -80,8 +80,11 @@ export const jobs = pgTable(
     function_execution_time_ms: integer("function_execution_time_ms"),
     timeout_interval_seconds: integer("timeout_interval_seconds")
       .notNull()
-      .default(3600),
+      .default(300),
     service: varchar("service", { length: 1024 }).notNull(),
+    predictive_retry_enabled: boolean("predictive_retry_enabled").default(
+      false,
+    ),
     predicted_to_be_retryable: boolean("predicted_to_be_retryable"), // null = unknown, no = not retryable, yes = retryable
     predicted_to_be_retryable_reason: text("predicted_to_be_retryable_reason"),
     predictive_retry_count: integer("predictive_retry_count").default(0),

--- a/control-plane/src/modules/deployment/lambda-cfn-provider.ts
+++ b/control-plane/src/modules/deployment/lambda-cfn-provider.ts
@@ -34,7 +34,10 @@ export class LambdaCfnProvider implements DeploymentProvider {
   public async create(deployment: Deployment): Promise<any> {
     const functionName = this.buildFunctionName(deployment);
 
-    console.log("Creating new lambda deployment", functionName);
+    logger.info("Creating new lambda deployment", {
+      deploymentId: deployment.id,
+      functionName,
+    });
 
     try {
       return await this.cfnManager.create({
@@ -55,7 +58,11 @@ export class LambdaCfnProvider implements DeploymentProvider {
   public async update(deployment: Deployment): Promise<any> {
     const functionName = this.buildFunctionName(deployment);
 
-    console.log("Updating existing lambda deployment", functionName);
+    logger.info("Updating existing lambda deployment", {
+      deploymentId: deployment.id,
+      functionName,
+    });
+
     const exists = await this.cfnManager.stackExists(functionName);
     if (!exists) {
       logger.warn("Stack does not exist. It will be created instead.");
@@ -86,7 +93,7 @@ export class LambdaCfnProvider implements DeploymentProvider {
     }
 
     try {
-      console.log("Triggering lambda", {
+      logger.info("Triggering lambda", {
         functionName,
         pendingJobs,
         runningMachines,

--- a/control-plane/src/modules/jobs/create-job.ts
+++ b/control-plane/src/modules/jobs/create-job.ts
@@ -36,16 +36,9 @@ export const createJob = async (params: {
   targetArgs: string;
   owner: { clusterId: string };
   deploymentId?: string;
-  cacheKey?: string;
   callConfig?: CallConfig;
 }) => {
   const end = jobDurations.startTimer({ operation: "createJob" });
-
-  const serviceDefinition = await functionDefinition(
-    params.owner,
-    params.service,
-    params.targetFn,
-  );
 
   const cluster = await clusters.operationalCluster(params.owner.clusterId);
 

--- a/control-plane/src/modules/jobs/jobs.test.ts
+++ b/control-plane/src/modules/jobs/jobs.test.ts
@@ -83,11 +83,6 @@ describe("nextJobs", () => {
       functions: [
         {
           name: Math.random().toString(),
-          rate: {
-            per: "minute" as const,
-            limit: 1000,
-          },
-          cacheTTL: 1000,
         },
       ],
     };
@@ -113,34 +108,17 @@ describe("selfHealJobs", () => {
     const targetFn = "testTargetFn";
     const targetArgs = "testTargetArgs";
 
-    const fnDefinition = {
-      maxAttempts: 2,
-      name: "testTargetFn",
-      timeoutIntervalSeconds: 1,
-    };
-
-    // feed a service definition with retry config
-    await nextJobs({
-      owner,
-      limit: 10,
-      machineId: "testMachineId",
-      ip: "1.1.1.1",
-      service: "testService",
-      definition: {
-        name: "testService",
-        functions: [fnDefinition],
-      },
-    });
-
-    const saved = await functionDefinition(owner, "testService", targetFn);
-
-    expect(saved).toStrictEqual(fnDefinition);
-
     const createJobResult = await createJob({
       targetFn: mockTargetFn,
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      callConfig: {
+        retry: {
+          attempts: 2,
+        },
+        timeoutSeconds: 1,
+      },
     });
 
     // get the job, so that it moves to running state
@@ -179,36 +157,18 @@ describe("selfHealJobs", () => {
 
   it("should not retry a job that has reached max attempts", async () => {
     const owner = await createOwner();
-    const targetFn = "testTargetFn";
-
-    const fnDefinition = {
-      maxAttempts: 1,
-      name: "testTargetFn",
-      timeoutIntervalSeconds: 1,
-    };
-
-    // feed a service definition with retry config
-    await nextJobs({
-      owner,
-      limit: 10,
-      machineId: "testMachineId",
-      ip: "1.1.1.1",
-      service: "testService",
-      definition: {
-        name: "testService",
-        functions: [fnDefinition],
-      },
-    });
-
-    const saved = await functionDefinition(owner, "testService", targetFn);
-
-    expect(saved).toStrictEqual(fnDefinition);
 
     const createJobResult = await createJob({
       targetFn: mockTargetFn,
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      callConfig: {
+        retry: {
+          attempts: 1,
+        },
+        timeoutSeconds: 1,
+      },
     });
 
     // get the job, so that it moves to running state

--- a/control-plane/src/modules/management.ts
+++ b/control-plane/src/modules/management.ts
@@ -23,7 +23,6 @@ type Job = {
 type Machine = {
   id: string;
   description: string | null;
-  pool: string | null;
   lastPingAt: Date | null;
   ip: string | null;
   deploymentId: string | null;
@@ -143,7 +142,6 @@ export const getClusterDetailsForUser = async ({
     .select({
       id: data.machines.id,
       description: data.machines.description,
-      pool: data.machines.machine_type,
       lastPingAt: data.machines.last_ping_at,
       ip: data.machines.ip,
       deploymentId: data.machines.deployment_id,

--- a/control-plane/src/modules/packages/client-lib.ts
+++ b/control-plane/src/modules/packages/client-lib.ts
@@ -6,6 +6,7 @@ import {
 import * as data from "../data";
 import { ulid } from "ulid";
 import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { logger } from "../../utilities/logger";
 
 type ClientLibraryVersion = {
   id: string;
@@ -28,7 +29,7 @@ export const createClientLibraryVersion = async ({
   const previous = await previousVersion({ clusterId });
   const version = incrementVersion({ version: previous, increment });
 
-  console.log("Creating client library version", {
+  logger.info("Creating client library version", {
     version,
     previous,
     increment,

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -117,7 +117,7 @@ export const router = s.router(contract, {
       };
     }
 
-    const { targetFn, targetArgs, pool, service, cacheKey } = request.body;
+    const { targetFn, targetArgs, service, callConfig } = request.body;
 
     const deployment = owner.cloudEnabled
       ? await findActiveDeployment(owner.clusterId, service)
@@ -129,7 +129,7 @@ export const router = s.router(contract, {
       targetArgs,
       owner,
       deploymentId: deployment?.id,
-      cacheKey,
+      callConfig,
     });
 
     return {

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -738,8 +738,10 @@ export const router = s.router(contract, {
 
     try {
       await validateSignature(request.request.body as Record<string, unknown>);
-    } catch {
-      logger.error("SNS Signature validation failed");
+    } catch (error) {
+      logger.error("SNS Signature validation failed", {
+        error,
+      });
       return {
         status: 400,
       };
@@ -753,13 +755,22 @@ export const router = s.router(contract, {
     }
 
     if (request.body.Type == "SubscriptionConfirmation" && request.body.Token) {
-      await confirmSubscription({
-        Token: request.body.Token,
-        TopicArn: env.DEPLOYMENT_SNS_TOPIC,
-      });
-      logger.info("Confirmed SNS subscription", {
-        TopicArn: env.DEPLOYMENT_SNS_TOPIC,
-      });
+      try {
+        await confirmSubscription({
+          Token: request.body.Token,
+          TopicArn: env.DEPLOYMENT_SNS_TOPIC,
+        });
+        logger.info("Confirmed SNS subscription", {
+          TopicArn: env.DEPLOYMENT_SNS_TOPIC,
+        });
+      } catch (error) {
+        logger.error("Failed to confirm SNS subscription", {
+          error,
+        });
+        return {
+          status: 500,
+        };
+      }
     }
 
     if (

--- a/control-plane/src/modules/service-definitions.ts
+++ b/control-plane/src/modules/service-definitions.ts
@@ -28,15 +28,6 @@ export const serviceDefinitionsSchema = z.array(
       .array(
         z.object({
           name: z.string(),
-          rate: z
-            .object({
-              per: z.enum(["minute", "hour"]),
-              limit: z.number(),
-            })
-            .optional(),
-          cacheTTL: z.number().optional(),
-          timeoutIntervalSeconds: z.number().optional(),
-          maxAttempts: z.number().optional(),
         }),
       )
       .optional(),

--- a/infrastructure/cfn.yaml
+++ b/infrastructure/cfn.yaml
@@ -36,6 +36,10 @@ Resources:
                 - "s3:GetObject"
                 - "s3:DeleteObject"
               Resource: !Sub "arn:aws:s3:::${AssetUploadBucket}/*"
+            - Effect: Allow
+              Action:
+                - "s3:GetObject"
+              Resource: !Sub "arn:aws:s3:::${CfnTemplateBucket}/*"
         Users:
           - !Ref ControlPlaneUser
 
@@ -48,6 +52,8 @@ Resources:
           Statement:
             - Effect: Allow
               Action:
+                - "lambda:GetFunction"
+                - "lambda:DeleteFunction"
                 - "lambda:CreateFunction"
                 - "lambda:UpdateFunctionCode"
                 - "lambda:UpdateFunctionConfiguration"
@@ -59,6 +65,32 @@ Resources:
             - Effect: Allow
               Action: iam:PassRole
               Resource: !GetAtt DeploymentLambdaRuntimeRole.Arn
+        Users:
+          - !Ref ControlPlaneUser
+
+  DeploymentCloudFormationPolicy:
+      Type: AWS::IAM::Policy
+      Properties:
+        PolicyName: DeploymentCloudFormationPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - "sns:Publish"
+                - "sns:ConfirmSubscription"
+              Resource: !Ref DeploymentCloudFormationTopic
+            - Effect: Allow
+              Action:
+                - "cloudformation:CreateStack"
+                - "cloudformation:UpdateStack"
+                - "cloudformation:DescribeStacks"
+                - "cloudformation:GetTemplate"
+                - "cloudformation:ValidateTemplate"
+                - "cloudformation:CreateChangeSet"
+                - "cloudformation:ExecuteChangeSet"
+                - "cloudformation:DeleteStack"
+              Resource: "arn:aws:cloudformation:*:*:stack/differential-deployment-*"
         Users:
           - !Ref ControlPlaneUser
 

--- a/ts-core/src/call-config.ts
+++ b/ts-core/src/call-config.ts
@@ -1,0 +1,49 @@
+type CallConfig = {
+  $d: {
+    cache?: {
+      key: string;
+      ttlSeconds: number;
+    };
+    retry?: {
+      attempts: number;
+      predictive: boolean;
+    };
+    timeoutSeconds?: number;
+    executionId?: string;
+    background?: boolean;
+    // TODO: time travel
+  };
+};
+
+type AddParameters<
+  TFunction extends (...args: any) => any,
+  TParameters extends [...args: any],
+  TResult,
+> = (...args: [...Parameters<TFunction>, ...TParameters]) => TResult;
+
+export type CallConfiguredFunction<TFunction extends (...args: any) => any> =
+  AddParameters<TFunction, [CallConfig?], ReturnType<TFunction>>;
+
+export type CallConfiguredBackgroundFunction<
+  TFunction extends (...args: any) => any,
+> = AddParameters<TFunction, [CallConfig?], Promise<{ id: string }>>;
+
+export const extractCallConfig = (
+  args: any[],
+): {
+  callConfig?: CallConfig["$d"];
+  originalArgs: any[];
+} => {
+  const lastArg = args[args.length - 1];
+
+  if (typeof lastArg === "object" && lastArg !== null && "$d" in lastArg) {
+    return {
+      callConfig: lastArg.$d,
+      originalArgs: args.slice(0, args.length - 1),
+    };
+  }
+
+  return {
+    originalArgs: args,
+  };
+};


### PR DESCRIPTION
This is the part 1 of 2.

Refactor the backend for accepting a `callConfig` object as the last parameter of a function call.

```ts
type CallConfig = {
  $d: {
    cache?: { key: string; ttlSeconds: number };
    retry?: { attempts: number; predictive: boolean };
    timeoutSeconds?: number;
    executionId?: string;
  };
};
```

This will allow function calls to have per-call configuration of caching, retrying, timeouts - making the documentation much more simpler and relying less on the service definition.

This will be a breaking change for `cached` decorator and undocumented `retryable` decorator. Therefore, it should be merged with the part (2/2).