### PR TITLE
feat: Refactor IAM to use CF Service Role

### DIFF
--- a/control-plane/src/modules/deployment/cfn-manager.ts
+++ b/control-plane/src/modules/deployment/cfn-manager.ts
@@ -72,6 +72,7 @@ export class CloudFormationManager {
       OnFailure: "DELETE",
       NotificationARNs: [env.DEPLOYMENT_SNS_TOPIC],
       ClientRequestToken: clientRequestToken,
+      RoleARN: env.DEPLOYMENT_DEFAULT_SERVICE_ROLE,
     });
 
     const response = await this.cloudFormationClient.send(createStackCommand);
@@ -103,6 +104,7 @@ export class CloudFormationManager {
       Parameters: params,
       NotificationARNs: [env.DEPLOYMENT_SNS_TOPIC],
       ClientRequestToken: clientRequestToken,
+      RoleARN: env.DEPLOYMENT_DEFAULT_SERVICE_ROLE,
     });
 
     const response = await this.cloudFormationClient.send(updateStackCommand);

--- a/control-plane/src/utilities/env.ts
+++ b/control-plane/src/utilities/env.ts
@@ -59,6 +59,7 @@ let envSchema = z
     DEPLOYMENT_SNS_TOPIC: z.string().optional(),
     DEPLOYMENT_SCHEDULING_ENABLED: truthy.default(false),
     DEPLOYMENT_DEFAULT_PROVIDER: z.enum(["lambda", "mock"]).default("mock"),
+    DEPLOYMENT_DEFAULT_SERVICE_ROLE: z.string().optional(),
     AWS_ACCESS_KEY_ID: z.string().optional(),
     AWS_SECRET_ACCESS_KEY: z.string().optional(),
   })

--- a/docs/advanced/self-hosting.md
+++ b/docs/advanced/self-hosting.md
@@ -139,6 +139,7 @@ The following environment variables will need to be made available to the contro
 - `ASSET_UPLOAD_BUCKET`
 - `DEPLOYMENT_TEMPLATE_BUCKET`
 - `DEPLOYMENT_SNS_TOPIC`
+- `DEPLOYMENT_DEFAULT_SERVICE_ROLE`
 
 Values for these can be retrieved from the previously created CloudFormation stack:
 

--- a/infrastructure/cfn.yaml
+++ b/infrastructure/cfn.yaml
@@ -57,19 +57,8 @@ Resources:
             - Effect: Allow
               Action:
                 - "lambda:GetFunction"
-                - "lambda:DeleteFunction"
-                - "lambda:CreateFunction"
-                - "lambda:UpdateFunctionCode"
-                - "lambda:UpdateFunctionConfiguration"
-                - "lambda:PutFunctionConcurrency"
-                - "lambda:PutFunctionEventInvokeConfig"
-                - "lambda:ListTags"
-                - "lambda:TagResource"
                 - "lambda:InvokeFunction"
               Resource: "arn:aws:lambda:*:*:function:differential-deployment-*"
-            - Effect: Allow
-              Action: iam:PassRole
-              Resource: !GetAtt DeploymentLambdaRuntimeRole.Arn
         Users:
           - !Ref ControlPlaneUser
 
@@ -82,9 +71,12 @@ Resources:
           Statement:
             - Effect: Allow
               Action:
-                - "sns:Publish"
                 - "sns:ConfirmSubscription"
               Resource: !Ref DeploymentCloudFormationTopic
+            - Effect: Allow
+              Action:
+                - "iam:PassRole"
+              Resource: !GetAtt DeploymentCloudFormationServiceRole.Arn
             - Effect: Allow
               Action:
                 - "cloudformation:CreateStack"
@@ -140,6 +132,60 @@ Resources:
                   - "logs:PutLogEvents"
                 Resource: "arn:aws:logs:*:*:*"
 
+  DeploymentLambdaPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: DeploymentLambdaPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - "s3:GetObject"
+            Resource: !Sub "arn:aws:s3:::${AssetUploadBucket}/service_bundle/*"
+          - Effect: Allow
+            Action:
+              - "lambda:GetFunction"
+              - "lambda:DeleteFunction"
+              - "lambda:CreateFunction"
+              - "lambda:UpdateFunctionCode"
+              - "lambda:UpdateFunctionConfiguration"
+              - "lambda:PutFunctionConcurrency"
+              - "lambda:DeleteFunctionEventInvokeConfig"
+              - "lambda:PutFunctionEventInvokeConfig"
+              - "lambda:ListTags"
+              - "lambda:TagResource"
+              - "lambda:InvokeFunction"
+            Resource: "arn:aws:lambda:*:*:function:differential-deployment-*"
+          - Effect: Allow
+            Action: iam:PassRole
+            Resource: !GetAtt DeploymentLambdaRuntimeRole.Arn
+      Roles:
+        - !Ref DeploymentCloudFormationServiceRole
+
+  DeploymentCloudFormationServiceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: "DeploymentCloudFormationServiceRole"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service: "cloudformation.amazonaws.com"
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: "DeploymentCloudFormationServicePolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "sns:ListSubscriptions"
+                  - "sns:ListTopics"
+                  - "sns:Publish"
+                Resource: "*"
+
   ControlPlaneUser:
     Type: AWS::IAM::User
     Properties:
@@ -155,3 +201,6 @@ Outputs:
   DeploymentCloudFormationTopic:
     Description: SNS topic for subscribing to CloudFormation status updates
     Value: !Ref DeploymentCloudFormationTopic
+  DeploymentCloudFormationServiceRole:
+    Description: IAM Role used by CloudFormation to apply deployments
+    Value: !Ref DeploymentCloudFormationServiceRole


### PR DESCRIPTION
Refactor the IAM permissions to use a [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) for managing resources rather than providing the privileges directly to `ControlPlaneUser`