### PR TITLE
fix: Explicitly include agent source in build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,9 @@ jobs:
           JWKS_URL: ${{ secrets.JWKS_URL }}
           PREDICTOR_API_URL: ${{ secrets.PREDICTOR_API_URL }}
 
+      - uses: sliteteam/github-action-git-crypt-unlock@1.2.0
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+
       - name: Test builds
         run: npx lerna run build

--- a/control-plane/tsconfig.json
+++ b/control-plane/tsconfig.json
@@ -11,6 +11,7 @@
   },
   "include": [
     "src/index.ts",
-    "src/utilities/migrate.ts"
+    "src/utilities/migrate.ts",
+    "src/modules/agents/agent.ts"
   ]
 }


### PR DESCRIPTION
Explicitly include `agent.ts` so it is included in `tsc` output.